### PR TITLE
Add a withdrawal address hint

### DIFF
--- a/docs/guides/node-operator-manual.md
+++ b/docs/guides/node-operator-manual.md
@@ -183,6 +183,8 @@ You would need an RPC endpoint - a local node / RPC provider (eg Alchemy/Infura)
 
 > Please note, that the withdrawal address should be added to the Lido Node Operators Registry before it can submit the signing keys. Adding an address to the Node Operators Registry happens via DAO voting. When providing withdrawal address to be added to the Node Operators Registry, keep in mind the following:
 > - it is the address that will receive rewards;
+> - it is the address you will be using for key management;
+> - you should be able to access it at any time in case of emergency;
 > - you can use multi-sig for it if you wish to;
 > - you will not be able to replace it by another address/multi-sig later.
 

--- a/docs/guides/node-operator-manual.md
+++ b/docs/guides/node-operator-manual.md
@@ -183,7 +183,7 @@ You would need an RPC endpoint - a local node / RPC provider (eg Alchemy/Infura)
 
 > Please note, that the withdrawal address should be added to the Lido Node Operators Registry before it can submit the signing keys. Adding an address to the Node Operators Registry happens via DAO voting. When providing withdrawal address to be added to the Node Operators Registry, keep in mind the following:
 > - it is the address that will receive rewards;
-> - it is the address you will be using for key management;
+> - it is the address you will be using for submitting keys to Lido;
 > - you should be able to access it at any time in case of emergency;
 > - you can use multi-sig for it if you wish to;
 > - you will not be able to replace it by another address/multi-sig later.

--- a/docs/guides/node-operator-manual.md
+++ b/docs/guides/node-operator-manual.md
@@ -181,6 +181,11 @@ You would need an RPC endpoint - a local node / RPC provider (eg Alchemy/Infura)
 
 ### Submitting the keys
 
+> Please note, that the withdrawal address should be added to the Lido Node Operators Registry before it can submit the signing keys. Adding an address to the Node Operators Registry happens via DAO voting. When providing withdrawal address to be added to the Node Operators Registry, keep in mind the following:
+> - it is the address that will receive rewards;
+> - you can use multi-sig for it if you wish to;
+> - you will not be able to replace it by another address/multi-sig later.
+
 After generating the keys, a Node Operator submits them to the protocol. To do this, they send a
 transaction from the Node Operator’s withdrawal address to the `NodeOperatorsRegistry` contract
 instance, calling [`addSigningKeysOperatorBH` function] and with the following arguments:


### PR DESCRIPTION
Explained how the withdrawal address should be added to the Node Operators Registry before submitting keys.