### PR TITLE
Feature / adding devops team as a .github reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 **/yarn.lock @Jabher @kozlovzxc
 **/package-lock.json @Jabher @kozlovzxc
 .github @lidofinance/review-gh-workflows
+


### PR DESCRIPTION
### Description

As a follow up to [this discussion](https://www.notion.so/Securing-packages-updates-via-CODEOWNERS-c242e7bf8ffc4504bb5887445504c9ce), devops team decided to create a separate github team for each type of sensetive files.

This codeowners change will automatically add @lidofinance/review-gh-workflows team to each PR where `.github` was updated.
