### PR TITLE
feat: add kusama link to intro page

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -8,6 +8,7 @@ import TerraIcon from '@site/src/assets/TerraIcon'
 import SolanaIcon from '@site/src/assets/SolanaIcon'
 import PolygonIcon from '@site/src/assets/PolygonIcon'
 import CosmosIcon from '@site/src/assets/CosmosIcon'
+import KusamaIcon from '@site/src/assets/KusamaIcon'
 
 # Introduction
 
@@ -51,6 +52,13 @@ The docs provided on this site are focused on Lido Ethereum Liquid Staking Proto
   title="Cosmos"
   subtitle="stAtom"
   Icon={<CosmosIcon />}
+/>
+
+<GridLink
+  to="https://docs.kusama.lido.fi"
+  title="Kusama"
+  subtitle="stKSM"
+  Icon={<KusamaIcon />}
 />
 
 </Grid>


### PR DESCRIPTION
This PR adds a link to Kusama docs on intro page.
<img width="961" alt="image" src="https://user-images.githubusercontent.com/39704351/165707141-1e98e689-cb10-4b55-8800-47de4f8045a9.png">
