### PR TITLE
Removed lockfile codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
-**/yarn.lock @Jabher @kozlovzxc
-**/package-lock.json @Jabher @kozlovzxc
 .github @lidofinance/review-gh-workflows
 


### PR DESCRIPTION
# Overview

Due to expiration of first edition of [NPM package management policy](https://www.notion.so/NPM-package-management-policy-4b577937b07943f58d65f9f1d95b518f) we need to remove @kozlovzxc and @Jabher from CODEOWNERS.

Policy itself will be propagated for another month, you can find details about [second edition here](https://www.notion.so/NPM-package-management-policy-V2-32900bc1bbca45fba702540aef74b65d).