### PR TITLE
Discourage steth-price-feed usage by external integrations

### DIFF
--- a/docs/contracts/stable-swap-state-oracle.md
+++ b/docs/contracts/stable-swap-state-oracle.md
@@ -2,7 +2,7 @@
 
 ---
 ### Warning
-`StableSwapStateOracle` is not intended to be used as a part of external integrations.
+`StableSwapStateOracle` is deprecated and not intended to be used as a part of external integrations.
 
 ---
 

--- a/docs/contracts/stable-swap-state-oracle.md
+++ b/docs/contracts/stable-swap-state-oracle.md
@@ -1,5 +1,11 @@
 # StableSwapStateOracle
 
+---
+### Warning
+`StableSwapStateOracle` is not intended to be used as a part of external integrations.
+
+---
+
 - [Source Code](https://github.com/lidofinance/curve-merkle-oracle/blob/main/contracts/StableSwapStateOracle.sol)
 - [Deployed Contract](https://etherscan.io/address/0x3a6bd15abf19581e411621d669b6a2bbe741ffd6)
 

--- a/docs/contracts/steth-price-feed.md
+++ b/docs/contracts/steth-price-feed.md
@@ -1,5 +1,12 @@
 # StEthPriceFeed
 
+---
+
+### Warning
+`StEthPriceFeed` is not intended to be used as a part of external integrations.
+
+---
+
 - [Source Code](https://github.com/lidofinance/steth-price-feed/blob/main/contracts/StEthPriceFeed.vy)
 - [Deployed Contract](https://etherscan.io/address/0xab55bf4dfbf469ebfe082b7872557d1f87692fe6)
 

--- a/docs/contracts/steth-price-feed.md
+++ b/docs/contracts/steth-price-feed.md
@@ -3,7 +3,7 @@
 ---
 
 ### Warning
-`StEthPriceFeed` is not intended to be used as a part of external integrations.
+`StEthPriceFeed` is depracated and not intended to be used as a part of external integrations.
 
 ---
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -50,7 +50,7 @@
   - Chainlink stETH/USD Price Feed: [`0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8`](https://etherscan.io/address/0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8) ([steth-usd.data.eth](https://app.ens.domains/name/steth-usd.data.eth))
   - Chainlink stETH/ETH Price Feed: [`0x86392dC19c0b719886221c78AB11eb8Cf5c52812`](https://etherscan.io/address/0x86392dC19c0b719886221c78AB11eb8Cf5c52812)
 
-- Reserve price feeds (conserved)
+- Reserve price feeds (obsolete)
   - stETH/ETH Merkle Price Oracle [`0x3a6bd15abf19581e411621d669b6a2bbe741ffd6`](https://etherscan.io/address/0x3a6bd15abf19581e411621d669b6a2bbe741ffd6)
   - stETH/ETH Price Feed [`0xab55bf4dfbf469ebfe082b7872557d1f87692fe6`](https://etherscan.io/address/0xab55bf4dfbf469ebfe082b7872557d1f87692fe6) (proxy)
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -46,10 +46,13 @@
 
 ### Price feeds
 
-- Chainlink stETH/USD Price Feed: [`0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8`](https://etherscan.io/address/0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8) ([steth-usd.data.eth](https://app.ens.domains/name/steth-usd.data.eth))
-- Chainlink stETH/ETH Price Feed: [`0x86392dC19c0b719886221c78AB11eb8Cf5c52812`](https://etherscan.io/address/0x86392dC19c0b719886221c78AB11eb8Cf5c52812)
-- stETH/ETH Merkle Price Oracle [`0x3a6bd15abf19581e411621d669b6a2bbe741ffd6`](https://etherscan.io/address/0x3a6bd15abf19581e411621d669b6a2bbe741ffd6)
-- stETH/ETH Price Feed [`0xab55bf4dfbf469ebfe082b7872557d1f87692fe6`](https://etherscan.io/address/0xab55bf4dfbf469ebfe082b7872557d1f87692fe6) (proxy)
+- Primary price feeds
+  - Chainlink stETH/USD Price Feed: [`0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8`](https://etherscan.io/address/0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8) ([steth-usd.data.eth](https://app.ens.domains/name/steth-usd.data.eth))
+  - Chainlink stETH/ETH Price Feed: [`0x86392dC19c0b719886221c78AB11eb8Cf5c52812`](https://etherscan.io/address/0x86392dC19c0b719886221c78AB11eb8Cf5c52812)
+
+- Reserve price feeds (conserved)
+  - stETH/ETH Merkle Price Oracle [`0x3a6bd15abf19581e411621d669b6a2bbe741ffd6`](https://etherscan.io/address/0x3a6bd15abf19581e411621d669b6a2bbe741ffd6)
+  - stETH/ETH Price Feed [`0xab55bf4dfbf469ebfe082b7872557d1f87692fe6`](https://etherscan.io/address/0xab55bf4dfbf469ebfe082b7872557d1f87692fe6) (proxy)
 
 ### Reward Programs
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -51,8 +51,6 @@ module.exports = {
       items: [
         'contracts/lido',
         'contracts/lido-oracle',
-        'contracts/stable-swap-state-oracle',
-        'contracts/steth-price-feed',
         'contracts/node-operators-registry',
         'contracts/withdrawals-manager-stub',
         'contracts/wsteth',


### PR DESCRIPTION
- Remove the items from the sidebar
![image](https://user-images.githubusercontent.com/961317/203241333-279c966a-1875-4f9c-9f38-29d3cc999e2a.png)
- Put warning plates.
![image](https://user-images.githubusercontent.com/961317/203241557-96ff181d-530b-49d6-b9eb-4cb930a01607.png)
- Declare internal price feed as a reserve.
![image](https://user-images.githubusercontent.com/961317/203241640-84b6ec8a-f472-4c88-bb7b-2c3f57b26bf6.png)
