### PR TITLE
Fix: rollback burner addr on Goerli

### DIFF
--- a/docs/deployed-contracts/goerli.md
+++ b/docs/deployed-contracts/goerli.md
@@ -14,7 +14,7 @@
 - LidoExecutionLayerRewardsVault: [`0x94750381bE1AbA0504C666ee1DB118F68f0780D4`](https://goerli.etherscan.io/address/0x94750381bE1AbA0504C666ee1DB118F68f0780D4)
 - WithdrawalQueueERC721: [`0xCF117961421cA9e546cD7f50bC73abCdB3039533`](https://goerli.etherscan.io/address/0xCF117961421cA9e546cD7f50bC73abCdB3039533) (proxy)
 - WithdrawalVault: [`0xdc62f9e8C34be08501Cdef4EBDE0a280f576D762`](https://goerli.etherscan.io/address/0xdc62f9e8C34be08501Cdef4EBDE0a280f576D762) (proxy)
-- Burner of stETH: [`0xC1Bc16782BE0ce7A81421874A4d3E9B2B32391f2`](https://goerli.etherscan.io/address/0xC1Bc16782BE0ce7A81421874A4d3E9B2B32391f2)
+- Burner of stETH: [`0x20c61C07C2E2FAb04BF5b4E12ce45a459a18f3B1`](https://goerli.etherscan.io/address/0x20c61C07C2E2FAb04BF5b4E12ce45a459a18f3B1)
 - GateSeal: [`0x75A77AE52d88999D0b12C6e5fABB1C1ef7E92638`](https://goerli.etherscan.io/address/0x75A77AE52d88999D0b12C6e5fABB1C1ef7E92638)
 - MEV Boost Relay Allowed List: [`0xeabE95AC5f3D64aE16AcBB668Ed0efcd81B721Bc`](https://goerli.etherscan.io/address/0xeabe95ac5f3d64ae16acbb668ed0efcd81b721bc)
 - Legacy Oracle (obsolete): [`0x24d8451BC07e7aF4Ba94F69aCDD9ad3c6579D9FB`](https://goerli.etherscan.io/address/0x24d8451BC07e7aF4Ba94F69aCDD9ad3c6579D9FB) (proxy)


### PR DESCRIPTION
Use the old contract version because of the already provided `stETH` allowance.