### PR TITLE
Access: codeowners for contracts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 .github @lidofinance/review-gh-workflows
-
+docs/deployed-contracts @lidofinance/lido-eth-protocol
+docs/contracts @lidofinance/lido-eth-protocol


### PR DESCRIPTION
Define [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for the deployed and documented contracts.

