### PR TITLE
fix: Basic rewards list display #227

### DIFF
--- a/docs/guides/steth-integration-guide.md
+++ b/docs/guides/steth-integration-guide.md
@@ -170,9 +170,9 @@ Since wstETH represents the holder's share in the total amount of Lido-controlle
 
 **Basic example**:
 
-1) User wraps 1 stETH and gets 0.9803 wstETH (1 stETH = 0.9803 wstETH)
-2) A rebase happens, the wstETH price goes up by 5%
-3) User unwraps 0.9803 wstETH and gets 1.0499 stETH (1 stETH = 0.9337 wstETH)
+1. User wraps 1 stETH and gets 0.9803 wstETH (1 stETH = 0.9803 wstETH)
+2. A rebase happens, the wstETH price goes up by 5%
+3. User unwraps 0.9803 wstETH and gets 1.0499 stETH (1 stETH = 0.9337 wstETH)
 
 ### Goerli wstETH for testing
 


### PR DESCRIPTION
https://docs.lido.fi/guides/steth-integration-guide/#rewards-accounting

<img width="1025" alt="Screenshot 2023-06-29 at 14 51 37" src="https://github.com/lidofinance/docs/assets/102730938/078dea09-8ef8-4281-b521-2db096ece434">

Nice to have to read this as a list, not text:
```
1. User wraps 1 stETH and gets 0.9803 wstETH (1 stETH = 0.9803 wstETH) 
2. A rebase happens, the wstETH price goes up by 5% 
3. User unwraps 0.9803 wstETH and gets 1.0499 stETH (1 stETH = 0.9337 wstETH)
```

https://github.com/lidofinance/docs/issues/227#issue-1780592876