### PR TITLE
Updated NO Guide with reference to Easy track guide

### DIFF
--- a/docs/guides/easy-track-guide.md
+++ b/docs/guides/easy-track-guide.md
@@ -6,10 +6,11 @@ This document is intended for:
 
 The guide consists of two sections: [General overview](#general-overview) and [Operations HOWTO](#operations-howto). If you’re here for the technical details of interacting with Easy Track, feel free to skip to the latter.
 ## General overview
-### What is Easy Track motion
-Easy Track motion is a lightweight voting considered to have passed if the minimum objections threshold hasn’t been reached. As opposed to regular Aragon votings, Easy Track motions are cheaper (no need to vote ‘pro’, token holders only have to vote ‘contra’ if they have objections) and easier to manage (no need to ask broad DAO community vote on proposals that spark no debate).
-An Easy Track motion can be enacted if the minimum objections threshold of 0.5% of total LDO supply hasn't been reached within 72 hours after the motion has been started.
-To prevent motion spam, only up to 12 active motions can exist at the same time.
+### What is Easy Track Motion?
+Easy Track motion is a lightweight voting process that is considered to have passed if the minimum objections threshold hasn't been reached. In contrast to regular Aragon voting, Easy Track motions are more cost-effective (as token holders only need to vote 'contra' if they have objections, rather than voting 'pro') and easier to manage (eliminating the need for broad DAO community voting on proposals that do not spark significant debate).
+To enact an Easy Track motion, the minimum objections threshold must not be reached within 72 hours after the motion has been initiated. The threshold requires support from at least 0.5% of the total LDO supply to reject the motion.
+
+To prevent motion spam, only up to 20 active motions can exist simultaneously.
 ### Motivation behind Easy Track
 Initially, the Lido DAO governance used to rely on Aragon voting model. The DAO approved or rejected proposals by direct governance token voting. Though transparent and reliable, it is not a convenient way to make decisions only affecting small groups of Lido DAO members. Besides, direct token voting didn’t exactly reflect all the decision-making processes within the Lido DAO and was often used only to adopt an existing consensus. Votings on such decisions often struggled to attract wider DAO attention and thus, to pass.
 Easy Track has been developed as a solution to problem of the DAO getting tired of governance.
@@ -26,18 +27,23 @@ For more in-depth technical description, please read through the full project [s
 - [LEGO guide to Easy Track](#lego-guide-to-easy-track)
 - [Rewards Committee guide to Easy Track](#rewards-committee-guide-to-easy-track)
 ## Node Operators guide to Easy Track
-There are several features of staking limit related Easy Track motions to keep in mind before starting one:
-1. **A node operator can only increase staking limits for themselves.** Before starting a motion, please make sure you have access to the address associated with the right node operator in the Lido Node Operators Registry. The correct address can be looked up in the Aragon UI ([goerli-prater testnet](https://testnet.testnet.fi/#/lido-testnet-prater/0x9d4af1ee19dad8857db3a45b0374c81c8a1c6320/), [mainnet](https://mainnet.lido.fi/#/lido-dao/0x55032650b14df07b85bf18a3a3ec8e0af2e028d5/)). 
-3. **Single motion can only address staking limit of a single node operator.** Increasing limits for several node operators in one motion isn't supported.
-3. **Total amount of node operator's signing keys must be greater than or equal to the new staking limit.** Make sure you have submitted enough valid signing keys before starting a motion.
+
+Before starting an Easy Track motion to increase staking limits, there are several key features to keep in mind:
+
+1. **Node operators can only increase staking limits for themselves.** Before initiating a motion, ensure that you have access to the address associated with the correct node operator in the Lido Node Operators Registry. You can find the correct address in the Aragon UI ([goerli-prater testnet](https://testnet.testnet.fi/#/lido-testnet-prater/0x9d4af1ee19dad8857db3a45b0374c81c8a1c6320/), [mainnet](https://mainnet.lido.fi/#/lido-dao/0x55032650b14df07b85bf18a3a3ec8e0af2e028d5/)). 
+2. **A single motion can only address the staking limit of a single node operator.** It is not possible to increase limits for multiple node operators in one motion.
+3. **The total amount of a node operator's signing keys must be greater than or equal to the new staking limit.** Make sure you have submitted enough valid signing keys before starting a motion.
+
 ### Conducting an Easy Track motion
-To start a staking limit Easy Track motion, proceed to Easy Track UI ([goerli-prater testnet](https://easytrack.testnet.fi/), [mainnet](https://easytrack.lido.fi/)).  
-Connect your wallet using the 'Connect wallet' button top right. Please use the address specified as your reward address in the Node Operators Registry.
-In the header menu click 'Start motion' button. You will see the motion creation interface. Motion type you are looking for is 'Increase node operator staking limit'.  
-Fill in the form (all fields are required).  
-Your node operator ID can be looked up in the Aragon UI ([goerli-prater testnet](https://testnet.testnet.fi/#/lido-testnet-prater/0x9d4af1ee19dad8857db3a45b0374c81c8a1c6320/), [mainnet](https://mainnet.lido.fi/#/lido-dao/0x55032650b14df07b85bf18a3a3ec8e0af2e028d5/)) – it is the number you can see to the left from your node operator name.  
-Fill the desired staking limit value in the 'New limit' field.  
-Press 'Submit' button below the form and sign the transaction (gas costs apply).  
+
+To initiate a staking limit Easy Track motion, follow these steps:
+
+1. Proceed to the Easy Track UI ([goerli-prater testnet](https://easytrack.testnet.fi/), [mainnet](https://easytrack.lido.fi/))
+2. Connect your wallet using the 'Connect wallet' button in the top right corner. Please use the address specified as your reward address in the Node Operators Registry.
+3. In the header menu click 'Start motion' button. You will be directed to the motion creation interface. Look for the motion type 'Increase node operator staking limit'.
+4. Fill in all fields in the form. Your node operator ID can be found in the Aragon UI ([goerli-prater testnet](https://testnet.testnet.fi/#/lido-testnet-prater/0x9d4af1ee19dad8857db3a45b0374c81c8a1c6320/), [mainnet](https://mainnet.lido.fi/#/lido-dao/0x55032650b14df07b85bf18a3a3ec8e0af2e028d5/)) – It is the number displayed to the left of your node operator name.
+5. Enter the desired staking limit value in the 'New limit' field, press the 'Submit' button below the form and sign the transaction (gas costs apply).
+   
 As soon as transaction is confirmed, the motion has been started and you can see it on the 'Active motions' page of Easy Track UI. Notifications will be sent out to let the DAO know about the motion. From this moment on, the LDO token holders will have 72 hours to submit their objections if they have any. Please note the motion duration may be different for testnet deployment.
 ### Possible motion outcomes
 A motion can have three possible outcomes:

--- a/docs/guides/node-operators/validator-keys.md
+++ b/docs/guides/node-operators/validator-keys.md
@@ -1,5 +1,13 @@
 # Validator Keys
 
+Validator keys are added in several sequential steps. These steps are similar for each time new keys are added.
+1. [Generating signing keys](#generating-signing-keys)
+2. [Validating these keys](#validating-the-keys)
+3. [Submitting the keys to the Node Operator Registry](#submitting-the-keys)
+4. [Importing the keys to a validator client](#importing-the-keys-to-a-lighthouse-validator-client)
+5. [Checking the keys](#checking-the-keys-of-all-lido-node-operators)
+6. [Submitting a motion to increase the staking limit](#increasing-the-staking-limits-with-an-easy-track-motion)
+
 ## Generating signing keys
 
 Upon inclusion into the protocol, a Node Operator should generate and submit a set of [BLS12-381]
@@ -230,3 +238,11 @@ If the new keys are present and valid, Node Operators can vote for increasing th
 #### You spot invalid keys
 
 It is urgent to notify Lido team and other Node Operators as soon as possible. For example, in the group chat.
+
+## Increasing the Staking Limits with an Easy Track motion
+
+Once new keys are present and valid, a motion can be proposed to increase the staking limit for the Node Operator.
+
+[Node Operators Guide to Easy Track](https://docs.lido.fi/guides/easy-track-guide#node-operators-guide-to-easy-track)
+
+


### PR DESCRIPTION
Added an extra step for the Validator Keys part, just a reference to the easy track guide. (avoiding redundancy).
Changed the easy track limit to 20 from 12 (in the guide).
some readability changes to both the Validator Keys part as well as the easy track guide.