### PR TITLE
Codeowners: update ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 .github @lidofinance/review-gh-workflows
-docs/deployed-contracts @lidofinance/lido-eth-protocol
+docs/deployed-contracts @lidofinance/lido-dao-ops-team
+docs/guides @lidofinance/lido-dao-ops-team
+docs/guides/lido-tokens-integration-guide.md @lidofinance/lido-eth-protocol
+docs/security @lidofinance/lido-eth-protocol
+docs/security/bugbounty.md @lidofinance/lido-dao-ops-team
 docs/contracts @lidofinance/lido-eth-protocol


### PR DESCRIPTION
- `deployed-contracts` to `lido-dao-ops-team`
- `guides` to `lido-dao-ops-team`
   - except tokens integration guide: `lido-eth-protocol`
- `security` to `lido-eth-protocol`
   - except `bugbounty` to `lido-dao-ops-team`