### PR TITLE
Add Bonadocs Widget to lido.md

### DIFF
--- a/docs/contracts/lido.md
+++ b/docs/contracts/lido.md
@@ -244,9 +244,8 @@ tokens to the `msg.sender` address.
 
 See <https://lido.fi/referral> for referral program details.
 
-```sol
-function submit(address _referral) payable returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="submit(address)" />
 
 | Parameter   | Type      | Description               |
 | ----------- | --------- | ------------------------- |
@@ -258,9 +257,8 @@ Returns the number of `StETH` shares generated.
 
 Returns the amount of ether temporarily buffered on the contract's balance.
 
-```sol
-function getBufferedEther() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getBufferedEther()" />
 
 :::note
 The buffered balance is kept on the contract from the moment the funds are received from a user until the moment
@@ -272,9 +270,8 @@ or [`WithdrawalsQueueERC721`](/contracts/withdrawal-queue-erc721)
 
 Returns staking state: whether it's paused or not.
 
-```sol
-function isStakingPaused() view returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="isStakingPaused()" />
 
 :::note
 'staking' here means the ability to accept new [submit](/contracts/lido#submit) requests
@@ -284,9 +281,8 @@ function isStakingPaused() view returns (bool)
 
 Returns how much ether can be staked in the current block.
 
-```sol
-function getCurrentStakeLimit() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getCurrentStakeLimit()" />
 
 :::note
 Special return values:
@@ -299,17 +295,8 @@ Special return values:
 
 Returns full info about current stake limit parameters and state.
 
-```sol
-function getStakeLimitFullInfo() view returns (
-    bool isStakingPaused,
-    bool isStakingLimitSet,
-    uint256 currentStakeLimit,
-    uint256 maxStakeLimit,
-    uint256 maxStakeLimitGrowthBlocks,
-    uint256 prevStakeLimit,
-    uint256 prevStakeBlockNumber
-)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getStakeLimitFullInfo()" />
 
 | Name                        | Type      | Description                                                             |
 | --------------------------- | --------- | ----------------------------------------------------------------------- |
@@ -329,9 +316,8 @@ Deposit buffered ether to the StakingRouter's module with the id of `_stakingMod
 
 Can be called only by [DepositSecurityModule](./deposit-security-module.md) contract.
 
-```sol
-function deposit(uint256 _maxDeposits, uint256 _stakingModuleId, bytes _depositCalldata)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="deposit(uint256,uint256,bytes)" />
 
 | Parameter         | Type      | Description                              |
 | ----------------- | --------- | ---------------------------------------- |
@@ -343,17 +329,15 @@ function deposit(uint256 _maxDeposits, uint256 _stakingModuleId, bytes _depositC
 
 Returns the amount of ether available to deposit.
 
-```sol
-function getDepositableEther() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getDepositableEther()" />
 
 ### canDeposit()
 
 Returns `true` if depositing buffered ether to the consensus layer is allowed.
 
-```sol
-function canDeposit() view returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="canDeposit()" />
 
 ## Accounting-related methods
 
@@ -364,19 +348,8 @@ if beacon balance increased, performs withdrawal requests finalization.
 
 Can be called only by [AccountingOracle](./accounting-oracle.md) contract.
 
-```sol
-function handleOracleReport(
-    uint256 _reportTimestamp,
-    uint256 _timeElapsed,
-    uint256 _clValidators,
-    uint256 _clBalance,
-    uint256 _withdrawalVaultBalance,
-    uint256 _elRewardsVaultBalance,
-    uint256 _sharesRequestedToBurn,
-    uint256[] _withdrawalFinalizationBatches,
-    uint256 _simulatedShareRate
-) returns (uint256[4] postRebaseAmounts)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="handleOracleReport(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[],uint256)" />
 
 | Parameter                        | Type       | Description                                                       |
 | -------------------------------- | ---------- | ----------------------------------------------------------------- |
@@ -403,9 +376,8 @@ Returns a fixed array of 4 values that represents changes made during the report
 
 Returns the entire amount of ether controlled by the protocol
 
-```sol
-function getTotalPooledEther() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getTotalPooledEther()" />
 
 :::note
 The sum of all ETH balances in the protocol, equals to the total supply of `stETH`.
@@ -415,21 +387,15 @@ The sum of all ETH balances in the protocol, equals to the total supply of `stET
 
 Returns the total amount of execution layer rewards collected to Lido contract buffer.
 
-```sol
-function getTotalELRewardsCollected() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getTotalELRewardsCollected()" />
 
 ### getBeaconStat()
 
 Returns the tuple of key statistics related to the Beacon Chain.
 
-```sol
-function getBeaconStat() view returns (
-    uint256 depositedValidators,
-    uint256 beaconValidators,
-    uint256 beaconBalance
-)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getBeaconStat()" />
 
 | Name                  | Type      | Description                                                                    |
 | --------------------- | --------- | ------------------------------------------------------------------------------ |
@@ -447,17 +413,15 @@ function getBeaconStat() view returns (
 A payable function for execution layer rewards.
 Can be called only by the [`LidoExecutionLayerRewardsVault`](./lido-execution-layer-rewards-vault.md) contract.
 
-```sol
-function receiveELRewards() payable
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="receiveELRewards()" />
 
 ### receiveWithdrawals()
 
 A payable function for withdrawals acquisition. Can be called only by [`WithdrawalVault`](./withdrawal-vault.md).
 
-```sol
-function receiveWithdrawals() payable
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="receiveWithdrawals()" />
 
 ## Protocol levers
 
@@ -467,9 +431,8 @@ Stop pool routine operations.
 
 Can be called only by the bearer of `PAUSE_ROLE`
 
-```sol
-function stop()
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="stop()" />
 
 ### resume()
 
@@ -477,9 +440,8 @@ Resume pool routine operations.
 
 Can be called only by the bearer of `RESUME_ROLE`
 
-```sol
-function resume()
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="resume()" />
 
 ### pauseStaking()
 
@@ -487,9 +449,8 @@ Stops accepting new ether to the protocol.
 
 Can be called only by the bearer of `STAKING_PAUSE_ROLE`
 
-```sol
-function pauseStaking()
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="pauseStaking()" />
 
 :::note
 While accepting new ether is stopped, calls to the `submit` function,
@@ -502,9 +463,8 @@ Resumes accepting new ether to the protocol (if `pauseStaking` was called previo
 
 Can be called only by the bearer of `STAKING_CONTROL_ROLE`
 
-```sol
-function resumeStaking()
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="resumeStaking()" />
 
 :::note
 Staking could be rate-limited by imposing a limit on the stake amount at each moment in time,
@@ -529,9 +489,8 @@ Limit explanation scheme:
     * │     ^      ^          ^   ^^^  ^ ^ ^     ^^^ ^     Stake events
 ```
 
-```sol
-function setStakingLimit(uint256 _maxStakeLimit, uint256 _stakeLimitIncreasePerBlock)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="setStakingLimit(uint256,uint256)" />
 
 | Parameter                     | Type      | Description                           |
 | ----------------------------- | --------- | ------------------------------------- |
@@ -553,9 +512,8 @@ Removes the staking rate limit.
 
 Can be called only by the bearer of `STAKING_CONTROL_ROLE`
 
-```sol
-function removeStakingLimit()
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="removeStakingLimit()" />
 
 ### unsafeChangeDepositedValidators()
 
@@ -580,9 +538,8 @@ The method might break the internal protocol state if applied incorrectly
 
 Returns the name of the token.
 
-```sol
-function name() view returns (string)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="name()" />
 
 :::note
 Always returns `Liquid staked Ether 2.0`.
@@ -592,9 +549,8 @@ Always returns `Liquid staked Ether 2.0`.
 
 Returns the symbol of the token.
 
-```sol
-function symbol() view returns (string)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="symbol()" />
 
 :::note
 Always returns `stETH`.
@@ -604,9 +560,8 @@ Always returns `stETH`.
 
 Returns the number of decimals for getting user representation of a token amount.
 
-```sol
-function decimals() view returns (uint8)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="decimals()" />
 
 :::note
 Always returns `18`.
@@ -616,9 +571,8 @@ Always returns `18`.
 
 Returns the number of tokens in existence.
 
-```sol
-function totalSupply() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="totalSupply()" />
 
 :::note
 Always equals to `getTotalPooledEther()` since the token amount
@@ -629,9 +583,8 @@ is pegged to the total amount of ether controlled by the protocol.
 
 Returns the number of tokens owned by the `_account`
 
-```sol
-function balanceOf(address _account) view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="balanceOf(address)" />
 
 :::note
 Balances are dynamic and equal the `_account`'s share in the amount of
@@ -643,9 +596,8 @@ total ether controlled by the protocol. See [`sharesOf`](/contracts/lido#shareso
 Returns the remaining number of tokens that `_spender` is allowed to spend
 on behalf of `_owner` through `transferFrom()`. This is zero by default.
 
-```sol
-function allowance(address _owner, address _spender) view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="allowance(address,address)" />
 
 | Parameter  | Type      | Description        |
 | ---------- | --------- | ------------------ |
@@ -660,9 +612,8 @@ This value changes when `approve()` or `transferFrom()` is called unless the all
 
 Sets `_amount` as the allowance of `_spender` over the caller's tokens
 
-```sol
-function approve(address _spender, uint256 _amount) returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="approve(address,uint256)" />
 
 | Parameter  | Type      | Description        |
 | ---------- | --------- | ------------------ |
@@ -684,9 +635,8 @@ Atomically increases the allowance granted to `_spender` by the caller by `_adde
 
 This is an alternative to `approve()` that can be used as a mitigation for problems described [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol#L42).
 
-```sol
-function increaseAllowance(address _spender, uint256 _addedValue) returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="increaseAllowance(address,uint256)" />
 
 | Parameter     | Type      | Description                            |
 | ------------- | --------- | -------------------------------------- |
@@ -709,9 +659,8 @@ Atomically decreases the allowance granted to `_spender` by the caller by `_subt
 This is an alternative to `approve()` that can be used as a mitigation for
 problems described [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol#L42).
 
-```sol
-function decreaseAllowance(address _spender, uint256 _subtractedValue) returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="decreaseAllowance(address,uint256)" />
 
 | Parameter          | Type      | Description                            |
 | ------------------ | --------- | -------------------------------------- |
@@ -732,9 +681,8 @@ Requirements:
 
 Moves `_amount` tokens from the caller's account to the `_recipient` account.
 
-```sol
-function transfer(address _recipient, uint256 _amount) returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="transfer(address,uint256)" />
 
 | Parameter    | Type      | Description                  |
 | ------------ | --------- | ---------------------------- |
@@ -757,13 +705,8 @@ Moves `_amount` tokens from `_sender` to `_recipient` using the
 allowance mechanism. `_amount` is then deducted from the caller's
 allowance.
 
-```sol
-function transferFrom(
-    address _sender,
-    address _recipient,
-    uint256 _amount
-) returns (bool)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="transferFrom(address,address,uint256)" />
 
 | Parameter    | Type      | Description          |
 | ------------ | --------- | -------------------- |
@@ -789,41 +732,36 @@ Requirements:
 
 Returns the total amount of shares in existence.
 
-```sol
-function getTotalShares() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getTotalShares()" />
 
 ### sharesOf()
 
 Returns the number of shares owned by `_account`
 
-```sol
-function sharesOf(address _account) view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="sharesOf(address)" />
 
 ### getSharesByPooledEth()
 
 Returns the number of shares that corresponds to `_ethAmount` of the protocol-controlled ether.
 
-```sol
-function getSharesByPooledEth(uint256 _ethAmount) view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getSharesByPooledEth(uint256)" />
 
 ### getPooledEthByShares()
 
 Returns the amount of ether that corresponds to `_sharesAmount` token shares.
 
-```sol
-function getPooledEthByShares(uint256 _sharesAmount) view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getPooledEthByShares(uint256)" />
 
 ### transferShares()
 
 Moves token shares from the caller's account to the provided recipient account.
 
-```sol
-function transferShares(address _recipient, uint256 _sharesAmount) returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="transferShares(address,uint256)" />
 
 | Parameter       | Type      | Description                  |
 | --------------- | --------- | ---------------------------- |
@@ -844,13 +782,8 @@ Requirements:
 
 Moves `_sharesAmount` token shares from the `_sender` account to the `_recipient` using the allowance mechanism. The amount of tokens equivalent to `_sharesAmount` is then deducted from the caller's allowance.
 
-```sol
-function transferSharesFrom(
-    address _sender,
-    address _recipient,
-    uint256 _sharesAmount
-) returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="transferSharesFrom(address,address,uint256)" />
 
 | Parameter      | Type      | Description          |
 | -------------- | --------- | -------------------- |
@@ -876,17 +809,15 @@ Requirements:
 
 Returns the current nonce for the `owner`. This value must be included whenever a signature is generated for an ERC-2612 permit.
 
-```sol
-function nonces(address owner) view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="nonces(address)" />
 
 ### DOMAIN_SEPARATOR()
 
 Returns the domain separator used in the encoding of the signature for the ERC-2612 permit, as defined by EIP-712.
 
-```sol
-function DOMAIN_SEPARATOR() view returns (bytes32)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="DOMAIN_SEPARATOR()" />
 
 ### permit()
 
@@ -894,9 +825,8 @@ Sets `value` as the allowance of `spender` over `owner`'s tokens, given `owner`'
 
 Emits an Approval event.
 
-```sol
-function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="permit(address,address,uint256,uint256,uint8,bytes32,bytes32)" />
 
 | Parameter  | Type      | Description                    |
 | ---------- | --------- | -------------------------------|
@@ -924,14 +854,8 @@ over the EIP712-formatted function arguments.
 
 Returns the fields and values that describe the domain separator used by this contract for EIP-712
 
-```sol
-function eip712Domain() view returns (
-    string name,
-    string version,
-    uint256 chainId,
-    address verifyingContract
-)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="eip712Domain()" />
 
 ## General Methods
 
@@ -939,17 +863,15 @@ function eip712Domain() view returns (
 
 Returns the address of [LidoLocator](./lido-locator.md).
 
-```sol
-function getLidoLocator() view returns (address)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getLidoLocator()" />
 
 ### getContractVersion()
 
 Returns the current contract version.
 
-```sol
-function getContractVersion() view returns (uint256)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="getContractVersion()" />
 
 :::note
 Always returns `2`.
@@ -959,9 +881,8 @@ Always returns `2`.
 
 Overrides default AragonApp behavior to disallow recovery.
 
-```sol
-function transferToVault(address _token)
-```
+
+<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="transferToVault(address)" />
 
 | Parameter| Type      | Description                        |
 | -------- | --------- | ---------------------------------- |

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write docs/"
   },
   "dependencies": {
+    "@bonadocs/widget": "^1.0.0",
     "@docusaurus/core": "^2.4.3",
     "@docusaurus/plugin-client-redirects": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write docs/"
   },
   "dependencies": {
-    "@bonadocs/widget": "^1.0.0",
+    "@bonadocs/widget": "^1.0.1",
     "@docusaurus/core": "^2.4.3",
     "@docusaurus/plugin-client-redirects": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,8 @@
+﻿import React from 'react'
+import MDXComponents from '@theme-original/MDXComponents'
+import BonadocsWidget from '@bonadocs/widget'
+
+export default {
+  ...MDXComponents,
+  BonadocsWidget,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
+  integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
+
 "@algolia/autocomplete-core@1.9.3":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"
@@ -2179,6 +2184,23 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
+"@bonadocs/core@^1.0.0-alpha.1":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@bonadocs/core/-/core-1.0.0-alpha.2.tgz#7c28fa603579c3644680857b03e9397204c9005d"
+  integrity sha512-JotBM+demJx0l2ZfkY5Yufzk/mEr1a+wlTjqWdiFZ+12ipShIYl66qxrYaTuF212rcOnzsg+IU7hqMnoI961Vw==
+  dependencies:
+    axios "^1.6.2"
+    ethers "^6.9.0"
+
+"@bonadocs/widget@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@bonadocs/widget/-/widget-1.0.0.tgz#14c24b484fc85f5aff4a3415a73a0728d2eba208"
+  integrity sha512-9zon+HhM7FN8b1k9ed7kFABHPcBVBSCEhgXYh6n4Oq1aXJj1LribyzHhyuutdKh8GD3GSax52iG/VeAnzkcrWw==
+  dependencies:
+    "@bonadocs/core" "^1.0.0-alpha.1"
+    axios "^1.6.3"
+    ethers "^6.9.1"
+
 "@braintree/sanitize-url@^6.0.0":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz#6110f918d273fe2af8ea1c4398a88774bb9fc12f"
@@ -2850,6 +2872,18 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@noble/curves@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
+"@noble/hashes@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3170,6 +3204,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.15.tgz#de0e1fbd2b22b962d45971431e2ae696643d3f5d"
   integrity sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==
 
+"@types/node@18.15.13":
+  version "18.15.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
+  integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
+
 "@types/node@^17.0.5":
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
@@ -3462,6 +3501,11 @@ address@^1.0.1, address@^1.1.2:
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.1.tgz#25bb61095b7522d65b357baa11bc05492d4c8acd"
   integrity sha512-B+6bi5D34+fDYENiH5qOlA0cV2rAGKuWZ9LeyUUehbXy8e0VS9e498yO0Jeeh+iM+6KbfudHTFjXw2MmJD4QRA==
 
+aes-js@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
+  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -3642,6 +3686,11 @@ asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
@@ -3677,6 +3726,15 @@ axios@^0.25.0:
   integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
     follow-redirects "^1.14.7"
+
+axios@^1.6.2, axios@^1.6.3:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
+  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-loader@^8.2.5:
   version "8.3.0"
@@ -4152,6 +4210,13 @@ combine-promises@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/combine-promises/-/combine-promises-1.1.0.tgz#72db90743c0ca7aab7d0d8d2052fd7b0f674de71"
   integrity sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -4875,6 +4940,11 @@ delaunator@5:
   dependencies:
     robust-predicates "^3.0.0"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -5186,6 +5256,19 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+ethers@^6.9.0, ethers@^6.9.1:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.9.2.tgz#6f4632f62e2350fa8354ff28624027a175ef85a4"
+  integrity sha512-YpkrtILnMQz5jSEsJQRTpduaGT/CXuLnUIuOYzHA0v/7c8IX91m2J48wSKjzGL5L9J/Us3tLoUdb+OwE3U+FFQ==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.0"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "18.15.13"
+    aes-js "4.0.0-beta.5"
+    tslib "2.4.0"
+    ws "8.5.0"
+
 eval@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eval/-/eval-0.1.8.tgz#2b903473b8cc1d1989b83a1e7923f883eb357f85"
@@ -5420,6 +5503,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.7:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.4:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz#eda2eff6e22476a2688d10661688c47f611b37f3"
@@ -5438,6 +5526,15 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     schema-utils "2.7.0"
     semver "^7.3.2"
     tapable "^1.0.0"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -6693,7 +6790,7 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7529,6 +7626,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -8700,6 +8802,11 @@ ts-dedent@^2.2.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
@@ -9253,6 +9360,11 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 ws@^7.3.1:
   version "7.5.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,22 +2184,13 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
-"@bonadocs/core@^1.0.0-alpha.1":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@bonadocs/core/-/core-1.0.0-alpha.2.tgz#7c28fa603579c3644680857b03e9397204c9005d"
-  integrity sha512-JotBM+demJx0l2ZfkY5Yufzk/mEr1a+wlTjqWdiFZ+12ipShIYl66qxrYaTuF212rcOnzsg+IU7hqMnoI961Vw==
+"@bonadocs/widget@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@bonadocs/widget/-/widget-1.0.1.tgz#071e70df7c129c623af3908b80faa54c360a1d55"
+  integrity sha512-n8KPr07eXcU9NPKXLtpfSEttzwOKwvcV6x8+2xXto6BbM9+jS9ttzZsTWCAVfZsa9N/rOxZ2IG7c59Dnm6ucMw==
   dependencies:
-    axios "^1.6.2"
-    ethers "^6.9.0"
-
-"@bonadocs/widget@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@bonadocs/widget/-/widget-1.0.0.tgz#14c24b484fc85f5aff4a3415a73a0728d2eba208"
-  integrity sha512-9zon+HhM7FN8b1k9ed7kFABHPcBVBSCEhgXYh6n4Oq1aXJj1LribyzHhyuutdKh8GD3GSax52iG/VeAnzkcrWw==
-  dependencies:
-    "@bonadocs/core" "^1.0.0-alpha.1"
-    axios "^1.6.3"
-    ethers "^6.9.1"
+    axios "^1.6.5"
+    ethers "^6.10.0"
 
 "@braintree/sanitize-url@^6.0.0":
   version "6.0.2"
@@ -3727,7 +3718,7 @@ axios@^0.25.0:
   dependencies:
     follow-redirects "^1.14.7"
 
-axios@^1.6.2, axios@^1.6.3:
+axios@^1.6.5:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
   integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
@@ -5256,10 +5247,10 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-ethers@^6.9.0, ethers@^6.9.1:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.9.2.tgz#6f4632f62e2350fa8354ff28624027a175ef85a4"
-  integrity sha512-YpkrtILnMQz5jSEsJQRTpduaGT/CXuLnUIuOYzHA0v/7c8IX91m2J48wSKjzGL5L9J/Us3tLoUdb+OwE3U+FFQ==
+ethers@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.10.0.tgz#20f3c63c60d59a993f8090ad423d8a3854b3b1cd"
+  integrity sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==
   dependencies:
     "@adraffy/ens-normalize" "1.10.0"
     "@noble/curves" "1.2.0"


### PR DESCRIPTION
## Intro

The goal of this PR is to supercharge Lido’s documentation by adding interactive widgets that make it possible to interact with the protocol contracts directly inside the documentation. This results in better developer experience (DX) leading to an increase in protocol and app integrations for Lido.

Demo: https://www.loom.com/share/9affc4deecde438cb108efb4bd188c1c

## Contributors

@staa99 and @Atanda1 are current and former contributors to other web3 products and tools including Infura, The Graph, and Ethers.

## Outline

When reading the documentation, the explanation of the protocol contracts is great. However, developers have to setup a basic testing environment to interact with the contracts to better understand the behavior. The widget eliminates this by enabling developers to interact with the contract methods directly within the documentation. This greatly reduces integration time and the context switching that would otherwise be required, making Lido more developer-friendly.

We are looking to integrate the widget in the documentation pages through open source contributions. The widget will replace the function code sections with an interactive interface that enables developers to interact with the protocol function being described. In some of the guides, there are descriptions of workflows that involve a more involved operation than simply calling a single contract function. Adding the widget to such guides will help developers understand the docs better.

## Technical Information

The widget is an open-source library: [@bonadocs/widget](https://www.npmjs.com/package/@bonadocs/widget).

The list of protocol smart contracts, deployment addresses, ABIs, and other widget configuration are stored on IPFS at the URI `ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu`. We chose to store the data on IPFS to guarantee immutability of the contract information and addresses, preserving the safety of the widget.

## Summary of Changes

We installed the widget using

```bash
    yarn add @bonadocs/widget
```

Then we registered the widget in the MDXComponents at `src/theme/MDXComponents.js`. The file did not exist so we created it. It allows us to just use `<BonadocsWidget />` within the documentation without having to import it in each markdown file.


    import React from 'react'
    import MDXComponents from '@theme-original/MDXComponents'
    import BonadocsWidget from '@bonadocs/widget'
    
    export default {
      ...MDXComponents,
      BonadocsWidget,
    }

For this PR, we have only updated `docs/contracts/lido.md`. If this gets approved, we will proceed to add the widget to other pages. For each solidity function on the page, we replaced the static code block with the widget. For example, the submit function looks like this:

```markdown    
<BonadocsWidget widgetConfigUri="ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu" contract="Lido" functionKey="submit(address)" />
```
The `widgetConfigUri` property specifies the configuration for the widget. `contract` specifies the name of the contract as defined in the linked collection from the widget config, and `functionKey` specifies the function being described.

P.S: This contribution is sponsored by \[Arbitrum X Questbook grant\](https://www.questbook.app/dashboard/?grantId=0x706bc8efecb6002f00a052fe5688d0eb89ea45f4&chainId=10&proposalId=0x463&role=builder) through \[Bonadocs\](https://github.com/bonadocs) - \[Consensys Fellowship startup\](https://consensys.io/blog/introducing-the-first-cohort-of-the-consensys-fellowship-program-for-web3).