### PR TITLE
fix: broken link in intro to operator portal

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -109,7 +109,7 @@ A penalty is a form of reducing the validator’s stake, which is not online or 
 Being slashed means that the misbehaving validator is forced to exit the beacon chain at a point in the future, receiving a [number of penalties until it leaves](https://docs.prylabs.network/docs/how-prysm-works/validator-lifecycle#slashing-state). As a result of it, APR can also reduce.
 
 > **Performance of Lido validators**
-The better the underlying operator sets are, the more robust, resilient, and performant the underlying protocol. Check [Operator Statistics and Metrics](https://operatorportal.lido.fi/quarterly-operator-metrics).
+The better the underlying operator sets are, the more robust, resilient, and performant the underlying protocol. Check [Operator Statistics and Metrics](https://operatorportal.lido.fi/operator-statistics-and-metrics).
 
 Learn more about rewards and penalties - [ethereum.org](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/)
 


### PR DESCRIPTION
- fix broken link in CL section of intro to point to correct page in the operator portal