### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,7 @@
+* @lidofinance/lido-eth-protocol
 .github @lidofinance/review-gh-workflows
 docs/deployed-contracts @lidofinance/lido-dao-ops-team
 docs/guides @lidofinance/lido-dao-ops-team
 docs/guides/lido-tokens-integration-guide.md @lidofinance/lido-eth-protocol
-docs/security @lidofinance/lido-eth-protocol
 docs/multisigs @lidofinance/lido-dao-ops-team
 docs/security/bugbounty.md @lidofinance/lido-dao-ops-team
-docs/contracts @lidofinance/lido-eth-protocol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@ docs/guides @lidofinance/lido-dao-ops-team
 docs/guides/lido-tokens-integration-guide.md @lidofinance/lido-eth-protocol
 docs/multisigs @lidofinance/lido-dao-ops-team
 docs/security/bugbounty.md @lidofinance/lido-dao-ops-team
+docs/docs/staking-modules/csm @lidofinance/community-staking


### PR DESCRIPTION
- [x] Propose the protocol team to be the default code owner to not make significant changes slip out
- [x] Propose the CSM team to be the code owner for the CSM doc section