### PR TITLE
fix: referral program

### DIFF
--- a/docs/contracts/lido.md
+++ b/docs/contracts/lido.md
@@ -242,7 +242,7 @@ Allows users to submit their funds by sending it to the contract address
 Sends funds to the pool with the optional `_referral` parameter and mints `StETH`
 tokens to the `msg.sender` address.
 
-See [Lido Referral Program](https://research.lido.fi/t/rewards-share-program-2024/6812) for referral program details.
+See [Lido Rewards-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812) for referral program details.
 
 ```sol
 function submit(address _referral) payable returns (uint256)

--- a/docs/contracts/lido.md
+++ b/docs/contracts/lido.md
@@ -242,7 +242,7 @@ Allows users to submit their funds by sending it to the contract address
 Sends funds to the pool with the optional `_referral` parameter and mints `StETH`
 tokens to the `msg.sender` address.
 
-See [https://lido.fi/referral](https://lido.fi/referral) for referral program details.
+See [Lido Referral Program](https://research.lido.fi/t/rewards-share-program-2024/6812) for referral program details.
 
 ```sol
 function submit(address _referral) payable returns (uint256)

--- a/docs/integrations/wallets.md
+++ b/docs/integrations/wallets.md
@@ -1,8 +1,8 @@
 # Wallets
 
-If you are an Ethereum wallet provider, you can integrate Lido staking into your app or website and get [Lido referral rewards](https://lido.fi/referral).
+If you are an Ethereum wallet provider, you can integrate Lido staking into your app or website and get [Lido referral rewards](https://research.lido.fi/t/rewards-share-program-2024/6812).
 
-*To participate in [Lido Referral Program](https://lido.fi/referral), apply for whitelisting on [Lido Forum](https://research.lido.fi/t/referral-program-whitelisting-ethereum/1039).*
+*To participate in [Lido Referral Program](https://research.lido.fi/t/rewards-share-program-2024/6812), apply for whitelisting on [Lido Forum](https://research.lido.fi/t/referral-program-whitelisting-ethereum/1039).*
 
 ## Your referral link
 

--- a/docs/integrations/wallets.md
+++ b/docs/integrations/wallets.md
@@ -1,6 +1,6 @@
 # Wallets
 
-If you are an Ethereum wallet provider, you can integrate Lido staking into your app or website and get [Lido referral rewards](https://research.lido.fi/t/rewards-share-program-2024/6812).
+By integrating Lido staking into your app or website you may be eligible for [Lido Rewads-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812).
 
 *To participate in [Lido Referral Program](https://research.lido.fi/t/rewards-share-program-2024/6812), apply for whitelisting on [Lido Forum](https://research.lido.fi/t/referral-program-whitelisting-ethereum/1039).*
 

--- a/docs/integrations/wallets.md
+++ b/docs/integrations/wallets.md
@@ -2,7 +2,7 @@
 
 By integrating Lido staking into your app or website you may be eligible for [Lido Rewads-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812).
 
-*To participate in [Lido Referral Program](https://research.lido.fi/t/rewards-share-program-2024/6812), apply for whitelisting on [Lido Forum](https://research.lido.fi/t/referral-program-whitelisting-ethereum/1039).*
+*To participate in [Lido Rewards-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812), file your application following the onboarding process described.*
 
 ## Your referral link
 


### PR DESCRIPTION
Fix Lido Referral Program links

https://lido.fi/referral is no longer available (as well as https://lido.fi/rewards-share it redirects to). I propose to change the current link to the forum post: https://research.lido.fi/t/rewards-share-program-2024/6812