### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/guides/jumpgates.md
+++ b/docs/guides/jumpgates.md
@@ -14,7 +14,7 @@ Go to [Etherscan](https://etherscan.io/)  and open the Jumpgate page. Click the 
 - `bridge` is the address of the bridge. Currently, all jumpgates use only Wormhole Token bridge at [`0x3ee18B2214AFF97000D974cf647E7C347E8fa585`](https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585), and you can check the address against the [Wormhole docs](https://book.wormhole.com/reference/contracts.html);
 - `nonce` is always 0;
 - `owner` is the Aragon Agent at [`0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c`](https://etherscan.io/address/0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) verifiable against [Deployed contracts](/deployed-contracts/#dao-contracts);
-- `recipient` is the recipient address in hexadecimal form. For Solana, this will an encoded LDO token account. Use [Base 58 decoder](https://appdevtools.com/base58-encoder-decoder) to decode this hexadecimal sequence to the Solana address format.
+- `recipient` is the recipient address in hexadecimal form. For Solana, this will be an encoded LDO token account. Use [Base 58 decoder](https://appdevtools.com/base58-encoder-decoder) to decode this hexadecimal sequence to the Solana address format.
 - `recipientChain` is the target chain identifier. If the Jumpgate is using Wormhole bridge, you can check the id against the [Wormhole docs](https://book.wormhole.com/reference/contracts.html), Solana id is 1;
 - `renounceOwnership` should yield an error;
 - `token` is the address of the token being transferred, e.g. LDO at [0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32](https://etherscan.io/address/0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32). Check the LDO address against [Deployed contracts](/deployed-contracts/#dao-contracts).

--- a/docs/integrations/api.md
+++ b/docs/integrations/api.md
@@ -90,7 +90,7 @@ Optional Parameters:
 - `skip`: number - Amount of data items to skip.
 - `limit`: number - Maximum amount of data items to respond with.
 
-`skip` and `limit` params are used for pagination eg:
+`skip` and `limit` params are used for pagination, e.g.:
 
 ```
 skip: 0, limit: 100 = 1 page

--- a/docs/integrations/wallets.md
+++ b/docs/integrations/wallets.md
@@ -1,6 +1,6 @@
 # Wallets
 
-By integrating Lido staking into your app or website you may be eligible for [Lido Rewads-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812).
+By integrating Lido staking into your app or website you may be eligible for [Lido Rewards-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812).
 
 *To participate in [Lido Rewards-Share Program](https://research.lido.fi/t/rewards-share-program-2024/6812), file your application following the onboarding process described.*
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
1. Corrected "Rewads" to "Rewards".
2. "this will an encoded LDO token account" - the word "be" is missing after "will". 
3. "params are used for pagination eg" - it is better to use the full form "e.g." rather than "eg"

Please review the changes and let me know if any additional changes are needed.