### PR TITLE
 fix grammar in documentation

### DIFF
--- a/docs/contracts/eip712-steth.md
+++ b/docs/contracts/eip712-steth.md
@@ -3,7 +3,7 @@
 - [Source code](https://github.com/lidofinance/lido-dao/blob/master/contracts/0.8.9/EIP712StETH.sol)
 - [Deployed contract](https://etherscan.io/address/0x8F73e4C2A6D852bb4ab2A45E6a9CF5715b3228B7)
 
-`EIP712StETH` serves as a dedicated helper contract for `stETH`, crucial for complete support of [ERC-2612 compliant signed approvals](https://eips.ethereum.org/EIPS/eip-2612).
+`EIP712StETH` serves as a dedicated helper contract for `stETH`, crucial for the complete support of [ERC-2612 compliant signed approvals](https://eips.ethereum.org/EIPS/eip-2612).
 
 ## Why This Helper Is Needed
 

--- a/docs/ipfs/release-flow.md
+++ b/docs/ipfs/release-flow.md
@@ -35,13 +35,13 @@ The IPFS pinning and preparing ENS transactions in the workflow are facilitated
 by the [Blumen](https://github.com/StauroDEV/blumen) package, developed in collaboration with Lido.
 
 On every IPFS release, the content verification is carried out by both development and QA Lido contributors
-to ensure that there is no unexpected content added to the code during CI process.
+to ensure that there is no unexpected content added to the code during the CI process.
 The verification relies on hash comparisons, and if you want, you can also
 perform it using the [provided instructions](hash-verification.md).
 
 After the verification, the IPFS release is initiated, which results in adding
 the obtained pinning information to the application [releases page](https://github.com/lidofinance/ethereum-staking-widget/releases).
-The details about IPFS pinning (CID, IPFS providers, https gateway, source code archives) is attached to the release description.
+The details about IPFS pinning (CID, IPFS providers, https gateway, source code archives) are attached to the release description.
 
 ### Workflow steps
 

--- a/docs/staking-modules/csm/contracts/CSAccounting.md
+++ b/docs/staking-modules/csm/contracts/CSAccounting.md
@@ -793,7 +793,7 @@ function getBond(uint256 nodeOperatorId) public view returns (uint256);
 
 ### getCurveInfo
 
-Return bond curve for the given curve id
+Returns bond curve for the given curve id
 
 _Get default bond curve info if `curveId` is `0` or invalid_
 


### PR DESCRIPTION
1. docs/contracts/eip712-steth.md:
Added "the" before "complete support"
Reason: definite article needed as it refers to specific support
2. docs/ipfs/release-flow.md:
Added "the" before "CI process"
Changed "is" to "are" for "details are attached"
Reason: definite article needed before CI process and verb agreement with plural "details"
3. docs/contracts/lido-locator.md:
Changed "Return" to "Returns"
Reason: consistency with other function descriptions in documentation