### PR TITLE
validator-ejector-guide.md and multisig/committees.md

### DIFF
--- a/docs/guides/validator-ejector-guide.md
+++ b/docs/guides/validator-ejector-guide.md
@@ -152,7 +152,7 @@ Address of the [LidoLocator](https://github.com/lidofinance/lido-dao/blob/featur
 
 ### STAKING_MODULE_ID
 
-ID of the [StakingRouter](https://github.com/lidofinance/lido-dao/blob/feature/shapella-upgrade/contracts/0.8.9/StakingRouter.sol) contract module.
+ID of the [StakingRouter](https://github.com/lidofinance/core/blob/master/contracts/0.8.9/StakingRouter.sol) contract module.
 
 Currently, it has only one module ([NodeOperatorsRegistry](https://github.com/lidofinance/lido-dao/blob/feature/shapella-upgrade/contracts/0.4.24/nos/NodeOperatorsRegistry.sol)), it's id is `1`.
 

--- a/docs/multisigs/committees.md
+++ b/docs/multisigs/committees.md
@@ -55,7 +55,7 @@ LEGO LDO Top Up Allowed Recipients [`0x00caAeF11EC545B192f16313F53912E453c91458`
 
 **Easy Track contracts and roles:**
 
-AddAllowedRecipient: [`0x1F809D2cb72a5Ab13778811742050eDa876129b63`](https://etherscan.io/address/0x1F809D2cb72a5Ab13778811742050eDa876129b6)
+AddAllowedRecipient: [`0x1F809D2cb72a5Ab13778811742050eDa876129b6`](https://etherscan.io/address/0x1F809D2cb72a5Ab13778811742050eDa876129b6)
 
 - trustedcaller
 


### PR DESCRIPTION

Changes made:

1. docs/guides/validator-ejector-guide.md
- Old: https://github.com/lidofinance/lido-dao/blob/feature/shapella-upgrade/contracts/0.8.9/StakingRouter.sol
- New: https://github.com/lidofinance/core/blob/master/contracts/0.8.9/StakingRouter.sol
Reason: Updated link to current location in main repository

2. docs/multisig/committees.md
- Old: 0x1F809D2cb72a5Ab13778811742050eDa876129b63
- New: 0x1F809D2cb72a5Ab13778811742050eDa876129b6
Reason: Fixed incorrect contract address (removed extra '3' digit at the end)

These changes improve documentation accuracy and fix contract address errors.