### PR TITLE
Fix multiple typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ More information about document metadata fields available [there](https://docusa
 
 ### Documentation Sidebar
 
-The appereance of sidebar controlled manually via `sidebars.js` file. This file is used to:
+The appearance of sidebar controlled manually via `sidebars.js` file. This file is used to:
 
 - Group multiple related documents
 - Display a sidebar on each of those documents
@@ -85,7 +85,7 @@ This command generates static content into the `build` directory and can be serv
 
 Build and deploy happens automatically when pull request is merged to `main`branch or someone pushes to `main` branch directly.
 
-To build documentation locally and push builded version to the `gh-pages` branch use next command:
+To build documentation locally and push built version to the `gh-pages` branch use next command:
 
 ```console
 GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy

--- a/docs/contracts/oracle-report-sanity-checker.md
+++ b/docs/contracts/oracle-report-sanity-checker.md
@@ -882,4 +882,4 @@ event NegativeCLRebaseAccepted(uint256 refSlot, uint256 clTotalBalance, uint256 
 - **`refSlot`** — the reference slot for the report checked.
 - **`clTotalBalance`** — the total Consensus Layer balance.
 - **`clBalanceDecrease`** — the decrease of Consensus Layer balance during report.
-- **`maxAllowedCLRebaseNegativeSum`** — the maximul accepted negative rebase balance change without second opinion.
+- **`maxAllowedCLRebaseNegativeSum`** — the maximum accepted negative rebase balance change without second opinion.


### PR DESCRIPTION

## Changes
Files changed:
1. docs/contracts/oracle-report-sanity-checker.md:
- Old: "maximul"
- New: "maximum"

2. README.md:
- Old: "appereance"
- New: "appearance"
- Old: "builded"
- New: "built"

## Why needed
1. Fixes spelling errors for better accuracy and readability
2. Improves technical documentation professionalism
3. Maintains consistent English language usage