### PR TITLE
docs: Corrected Event Name in transferERC1155 Method Update insurance.md

### DIFF
--- a/docs/contracts/insurance.md
+++ b/docs/contracts/insurance.md
@@ -38,7 +38,7 @@ Transfer a single ERC1155 token with the specified id in the specified amount to
 - reverts if `msg.sender` is not `owner`;
 - reverts if `_recipient` is zero address;
 - reverts if the contract balance is insufficient;
-- emits `ERC721Transferred(address indexed _token, address indexed _recipient, uint256 _tokenId, bytes _data)`.
+- emits `ERC1155Transferred(address indexed _token, address indexed _recipient, uint256 _tokenId, bytes _data)`.
 
 ```solidity
 function transferERC1155(address _token, address _recipient, uint256 _tokenId, uint256 _amount, bytes calldata _data) external;


### PR DESCRIPTION
### Description

<img width="1165" alt="Снимок экрана 2024-12-23 в 11 50 04" src="https://github.com/user-attachments/assets/938e7c6e-3ea8-46ab-ab7b-66d7575a0dd2" />

I noticed that in the `transferERC1155` method, the event `ERC721Transferred` was incorrectly referenced in the comments. Since this method is designed to transfer ERC1155 tokens, the event should be `ERC1155Transferred` instead.

I've corrected the event name to reflect the proper standard and ensure consistency with the method's functionality. 
