### PR TITLE
docs: Fix minor typos and grammar improvements in token guides

### DIFF
--- a/docs/token-guides/steth-on-aave-caveats.md
+++ b/docs/token-guides/steth-on-aave-caveats.md
@@ -7,7 +7,7 @@ Due to internal stETH mechanics required for rebasing support, in most cases stE
 ### Workarounds
 There are two workarounds:
 
-- Have at least 1 stETH wei more than it is required to close the flashoan. In this case, the amount of stETH transferred will be equal to or 1 wei greater than the loaned amount.
+- Have at least 1 stETH wei more than it is required to close the flashloan. In this case, the amount of stETH transferred will be equal to or 1 wei greater than the loaned amount.
 - If leaving an extra wei is somehow not an option, you should check if the amount to transfer actually matches the loaned amount beforehand. This can be done using this formula:
 ```
     uint256 exactTransferedAmount = StETH.getPooledEthByShares(StETH.getSharesByPooledEth(amount))

--- a/docs/token-guides/wsteth-bridging-guide.md
+++ b/docs/token-guides/wsteth-bridging-guide.md
@@ -59,7 +59,7 @@ Usually, the Lido DAO recognizes the bridged wstETH endpoints if the specific se
 
 If the recommendations **R-1...R-4** are followed, the token may have a chance of being formally recognized by NEC as following the security and future-proofing baseline.
 
-If any of **R-1...R-4** isn’t followed, there can be less likelihood of the NEC recognition.
+If any of **R-1...R-4** aren’t followed, there can be less likelihood of the NEC recognition.
 
 ## General scenario towards the Lido DAO recognition
 


### PR DESCRIPTION
### Description

Hey! I came across a couple of small issues while reviewing the docs. Here's what I updated:

1. In the file `docs/token-guides/steth-on-aave-caveats.md`, I noticed a typo where "flashoan" was used instead of the correct term "flashloan." I’ve corrected it to ensure consistency and accuracy.

2. In the file `docs/token-guides/wsteth-bridging-guide.md`, there was a minor grammatical issue. The phrase "If any of R-1...R-4 isn’t followed, there can be less likelihood of the NEC recognition." needed a slight adjustment to use "aren’t" instead of "isn’t," since we're referring to multiple items (R-1, R-2, R-3, and R-4). I’ve corrected this to:  
   "If any of R-1...R-4 aren’t followed, there can be less likelihood of the NEC recognition."

Both changes should improve the clarity and correctness of the documentation.