### PR TITLE
Update github link in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,8 +2,8 @@
 module.exports = {
   title: 'Lido Docs',
   tagline: 'Documentation for the Lido staking protocol',
-  url: 'https://github.com/lidofinance',
-  baseUrl: '/',
+  url: 'https://github.com',
+  baseUrl: '/lidofinance',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'throw',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: 'Lido Docs',
   tagline: 'Documentation for the Lido staking protocol',
-  url: 'https://lidofinance.github.io',
+  url: 'https://github.com/lidofinance',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',


### PR DESCRIPTION
This seems to get used in a bunch of headers on every docs page, and links to the old lidofinance.github.com.