### PR TITLE
feat: update IPFS CID for Lido Ethereum Liquid Staking Widget

### DIFF
--- a/docs/ipfs/apps-list.md
+++ b/docs/ipfs/apps-list.md
@@ -4,7 +4,7 @@ This page is a source of up-to-date hashes of Lido applications deployed to the 
 
 - Lido Ethereum Liquid Staking Widget:
   - Release: [0.42.1](https://github.com/lidofinance/ethereum-staking-widget/releases/tag/0.42.1)
-  - CID: [`bafybeib3zmyqlmantvdd6i5q4ehmo4larvorgquyanne3uoqdbedwgh3aq`](https://bafybeib3zmyqlmantvdd6i5q4ehmo4larvorgquyanne3uoqdbedwgh3aq.ipfs.cf-ipfs.com)
+  - CID: [`bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u`](https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.flk-ipfs.xyz)
 - stETH as Anchor collateral widget:
   - Release: 0.24.0
-  - CID: [`bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha`](https://bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha.ipfs.cf-ipfs.com)
+  - CID: [`bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha`](https://bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha.ipfs.flk-ipfs.xyz)


### PR DESCRIPTION
Updates to IPFS CIDs:

* [`docs/ipfs/apps-list.md`](diffhunk://#diff-49d93c31a1141c04251dd076a07653a18c1046b275240056069efeb2987efcafL7-R10): Updated the CID for the Lido Ethereum Liquid Staking Widget
* [`docs/ipfs/apps-list.md`](diffhunk://#diff-49d93c31a1141c04251dd076a07653a18c1046b275240056069efeb2987efcafL7-R10): Updated the IPFS Gateway for the stETH as Anchor collateral widget to a new IPFS gateway.