### PR TITLE
chore: update Lido Ethereum Liquid Staking Widget to version 0.76.1

### DIFF
--- a/docs/ipfs/apps-list.md
+++ b/docs/ipfs/apps-list.md
@@ -3,7 +3,7 @@
 This page is a source of up-to-date hashes of Lido applications deployed to the IPFS.
 
 - Lido Ethereum Liquid Staking Widget:
-  - Release: [0.42.1](https://github.com/lidofinance/ethereum-staking-widget/releases/tag/0.42.1)
+  - Release: [0.76.1](https://github.com/lidofinance/ethereum-staking-widget/releases/tag/0.76.1)
   - CID: [`bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u`](https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.flk-ipfs.xyz)
 - stETH as Anchor collateral widget:
   - Release: 0.24.0


### PR DESCRIPTION

* Updated the release version of the Lido Ethereum Liquid Staking Widget from `0.42.1` to `0.76.1`.