### PR TITLE
fix: wrong name for registry address in validator-keys.md

### DIFF
--- a/docs/guides/node-operators/validator-keys.md
+++ b/docs/guides/node-operators/validator-keys.md
@@ -77,7 +77,7 @@ You would need an RPC endpoint - a local node / RPC provider (eg Alchemy/Infura)
 > - changing the address will require another DAO vote.
 
 After generating the keys, a Node Operator submits them to the protocol. To do this, they send a
-transaction from the Node Operator’s withdrawal address to the `NodeOperatorsRegistry` contract
+transaction from the Node Operator’s rewards address to the `NodeOperatorsRegistry` contract
 instance, calling [`addSigningKeys` function] and with the following arguments:
 
 ```

--- a/docs/guides/node-operators/validator-keys.md
+++ b/docs/guides/node-operators/validator-keys.md
@@ -68,13 +68,13 @@ You would need an RPC endpoint - a local node / RPC provider (eg Alchemy/Infura)
 
 ## Submitting the keys
 
-> Please note, that the withdrawal address should be added to the Lido Node Operators Registry before it can submit the signing keys. Adding an address to the Node Operators Registry happens via DAO voting. When providing withdrawal address to be added to the Node Operators Registry, keep in mind the following:
+> Please note, that the Node Operator's rewards address should be added to the Lido Node Operators Registry before it can submit the signing keys. Adding an address to the Node Operators Registry happens via DAO voting. When providing a rewards address to be added to the Node Operators Registry, keep the following in mind:
 >
 > - it is the address that will receive rewards;
-> - it is the address you will be using for submitting keys to Lido;
-> - you should be able to access it at any time in case of emergency;
-> - you can use multi-sig for it if you wish to;
-> - you will not be able to replace it by another address/multi-sig later.
+> - it is the address the NO will use to submit keys to Lido;
+> - the NO should be able to access it at any time in case of emergency;
+> - the address could be a multi-sig if that's preferred;
+> - changing the address will require another DAO vote.
 
 After generating the keys, a Node Operator submits them to the protocol. To do this, they send a
 transaction from the Node Operator’s withdrawal address to the `NodeOperatorsRegistry` contract


### PR DESCRIPTION
Changed the erroneous "withdrawal address" with "node operator's registry address". 

Also fixed some grammatical errors in the same paragraph.

## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Changed the erroneous "withdrawal address" with "node operator's registry address". 
2. fixed some grammatical errors in the same paragraph.

### 🔎 Include source of truth for all changes that reference on-chain data (addresses, etc.)
1. Node Operator registry address is called a "reward address":https://docs.lido.fi/contracts/node-operators-registry
