### PR TITLE
Update IPFS app links to use dweb.link for improved accessibility

### DIFF
--- a/docs/ipfs/apps-list.md
+++ b/docs/ipfs/apps-list.md
@@ -4,7 +4,7 @@ This page is a source of up-to-date hashes of Lido applications deployed to the 
 
 - Lido Ethereum Liquid Staking Widget:
   - Release: [0.76.1](https://github.com/lidofinance/ethereum-staking-widget/releases/tag/0.76.1)
-  - CID: [`bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u`](https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.flk-ipfs.xyz)
+  - CID: [`bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u`](https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.dweb.link)
 - stETH as Anchor collateral widget:
   - Release: 0.24.0
-  - CID: [`bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha`](https://bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha.ipfs.flk-ipfs.xyz)
+  - CID: [`bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha`](https://bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha.ipfs.dweb.link)


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
This pull request includes a small update to the `docs/ipfs/apps-list.md` file. The change updates the URLs for the CID links to use a different IPFS gateway.

* Updated CID links to use `dweb.link` instead of `flk-ipfs.xyz` in `docs/ipfs/apps-list.md`.

### 🔎 Include source of truth for all changes that reference on-chain data (addresses, etc.)
1. https://ipfs.github.io/public-gateway-checker/
