### PR TITLE
Fix: lift LIP-27 to the proposed state

### DIFF
--- a/docs/lips.md
+++ b/docs/lips.md
@@ -9,11 +9,12 @@ More details on the contribution process and LIPs statuses can be found [here](h
 | LIP&nbsp;# | Title | Author          | Discussions&#8209;to |
 |------------|-------|-----------------|----------------|
 | [0](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-0.md)  | LIP Purpose and Guidelines                                | Lido Community | [Link](https://research.lido.fi/t/lido-improvement-proposal-process/16) |
-| [27](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-27.md) | Ensuring Compatibility with Ethereum’s Pectra Upgrade | George Avsetsin | [Link](https://research.lido.fi/t/ensuring-compatibility-with-ethereum-s-pectra-upgrade/9444) |
 
 ## Proposed
 
-TBA
+| LIP&nbsp;# | Title | Author          | Discussions&#8209;to |
+|------------|-------|-----------------|----------------|
+| [27](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-27.md) | Ensuring Compatibility with Ethereum’s Pectra Upgrade | George Avsetsin | [Link](https://research.lido.fi/t/ensuring-compatibility-with-ethereum-s-pectra-upgrade/9444) |
 
 ## Implemented
 


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Lift `LIP-27` status from `WIP` to `Proposed`

### 🔎 Include source of truth for all changes that reference on-chain data (addresses, etc.)
1. https://github.com/lidofinance/lido-improvement-proposals/pull/76
