### PR TITLE
[WIP] Feat: Add MEV-Boost relay allowed list management ET factories 

### DIFF
--- a/docs/deployed-contracts/hoodi.md
+++ b/docs/deployed-contracts/hoodi.md
@@ -146,13 +146,18 @@ Currently, the main operational and maintained protocol testnet is being migrate
   - BokkyPooBah's DateTime Library: [`0xd1df0cf660d531fad9eaabd3e7b4e8881e28ae2f`](https://hoodi.etherscan.io/address/0xd1df0cf660d531fad9eaabd3e7b4e8881e28ae2f)
   - AllowedTokensRegistry: [`0x40Db7E8047C487bD8359289272c717eA3C34D1D3`](https://hoodi.etherscan.io/address/0x40db7e8047c487bd8359289272c717ea3c34d1d3)
 
+### Easy Track factories for MEV-Boost Relay Allowed List management
+- **MEV-Boost Relay Allowed List** (trusted caller is QA & DAO Ops ms [`0x418B816A7c3ecA151A31d98e30aa7DAa33aBf83A`](https://app.safe.protofire.io/home?safe=eth:0x418B816A7c3ecA151A31d98e30aa7DAa33aBf83A))
+  - AddMEVBoostRelays: [`0xF02DbeaA1Bbc90226CaB995db4C190DbE25983af`](https://hoodi.etherscan.io/address/0xF02DbeaA1Bbc90226CaB995db4C190DbE25983af)
+  - RemoveMEVBoostRelays : [`0x7FCc2901C6C3D62784cB178B14d44445B038f736`](https://hoodi.etherscan.io/address/0x7FCc2901C6C3D62784cB178B14d44445B038f736)
+  - EditMEVBoostRelay : [`0x27A99a7104190DdA297B222104A6C70A4Ca5A17e`](https://hoodi.etherscan.io/address/0x27A99a7104190DdA297B222104A6C70A4Ca5A17e)
+
 ## Testnet Stablecoins
 
   - USDC: [`0x97bb030B93faF4684eAC76bA0bf3be5ec7140F36`](https://hoodi.etherscan.io/address/0x97bb030B93faF4684eAC76bA0bf3be5ec7140F36)
   - USDT: [`0x64f1904d1b419c6889BDf3238e31A138E258eA68`](https://hoodi.etherscan.io/address/0x64f1904d1b419c6889BDf3238e31A138E258eA68)
   - DAI: [`0x17fc691f6EF57D2CA719d30b8fe040123d4ee319`](https://hoodi.etherscan.io/address/0x17fc691f6EF57D2CA719d30b8fe040123d4ee319)
-<!--
+
 ## Testnet DAO Multisigs
 
-==TODO==
--->
+- QA & DAO Ops ms: [`0x418B816A7c3ecA151A31d98e30aa7DAa33aBf83A`](https://app.safe.protofire.io/home?safe=holesky:0x418B816A7c3ecA151A31d98e30aa7DAa33aBf83A)

--- a/docs/deployed-contracts/index.md
+++ b/docs/deployed-contracts/index.md
@@ -280,6 +280,12 @@ for the rate and price feeds recommended approaches.
   - AllowedRecipientsFactory (multi token): [`0xEe60C6ebC91237d334230b12263E26EE3b480ec4`](https://etherscan.io/address/0xEe60C6ebC91237d334230b12263E26EE3b480ec4)
   - BokkyPooBah's DateTime Library: [`0x75100bd564415731b5936a4a94d0dc29dde5db3c`](https://etherscan.io/address/0x75100bd564415731b5936a4a94d0dc29dde5db3c)
 
+### Easy Track factories for MEV-Boost Relay Allowed List management
+- **MEV-Boost Relay Allowed List** (committee ms [`0x98be4a407Bff0c125e25fBE9Eb1165504349c37d`](https://app.safe.global/home?safe=eth:0x98be4a407Bff0c125e25fBE9Eb1165504349c37d))
+  - AddMEVBoostRelays: [`0x00A3D6260f70b1660c8646Ef25D0820EFFd7bE60`](https://etherscan.io/address/0x00A3D6260f70b1660c8646Ef25D0820EFFd7bE60)
+  - RemoveMEVBoostRelays : [`0x9721c0f77E3Ea40eD592B9DCf3032DaF269c0306`](https://etherscan.io/address/0x9721c0f77E3Ea40eD592B9DCf3032DaF269c0306)
+  - EditMEVBoostRelay : [`0x6b7863f2c7dEE99D3b744fDAEDbEB1aeCC025535`](https://etherscan.io/address/0x6b7863f2c7dEE99D3b744fDAEDbEB1aeCC025535)
+
 ## Lido DAO Multisigs
 
 ### Lido Contributors Group Multisigs


### PR DESCRIPTION


## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Adds three new EasyTrack factories addresses for the MEV-Boost Relay Allowed List management to mainnet and Hoodi chains
    * AddMEVBoostRelays
    * RemoveMEVBoostRelays
    * EditMEVBoostRelays

### 🔎 Include source of truth for all changes that reference on-chain data (addresses, etc.)
1. Cross-reference the addresses with the deployment artefacts in the easy-track repo:
    * [Mainnet](https://github.com/lidofinance/easy-track/blob/9c8353378b397621e38c562532b35d9956746b47/deployed-mainnet.json#L79)
    * [Hoodi](https://github.com/lidofinance/easy-track/blob/9c8353378b397621e38c562532b35d9956746b47/deployed-hoodi.json#L2)
