### PR TITLE
Update Hoodi V3 addresses

### DIFF
--- a/docs/deployed-contracts/hoodi-lidov3.md
+++ b/docs/deployed-contracts/hoodi-lidov3.md
@@ -1,7 +1,7 @@
 # Hoodi: Lido V3 testnet instance :eyes:
 
 :::info 🔬 **Experimental playground**
-This page documents the **very first public testnet deployment of Lido V3 (stVaults)**. The contracts listed below exist *only* on this test network and can be redeployed without notice.
+This page documents the **very first public testnet deployment of Lido V3 (stVaults)**. The contracts listed below exist _only_ on this test network and can be redeployed without notice.
 
 If you are looking for mainnet Lido V3 addresses – hang tight, they are not live yet.
 
@@ -12,8 +12,12 @@ If you are looking for mainnet Lido V3 addresses – hang tight, they are not li
 :::
 
 :::tip 📣 **Leave feedback** ← NEW
-Tried this testnet? Lido contributors would love to hear from you!  
+Tried this testnet? Lido contributors would love to hear from you!
 Take 30 s to drop your thoughts through **[this quick form](https://tally.so/r/3X9vYe)**.
+:::
+
+:::info **Deployment refreshed: testnet‑2**
+Hoodi V3 contracts were redeployed with new addresses. The list below shows current testnet‑2 endpoints. Previous testnet‑1 addresses are available at the bottom of the page.
 :::
 
 ## 📚 Further reading
@@ -24,6 +28,88 @@ Take 30 s to drop your thoughts through **[this quick form](https://tally.so/r
 - ⚓ [stVaults deployment tag: **`v3.0.0-alpha`**](https://github.com/lidofinance/core/releases/tag/v3.0.0-alpha)
 
 ---
+
+## 🏛️ Core protocol
+
+- Lido Locator: [`0xD7c1B80fA86965B48cCA3aDcCB08E1DAEa291980`](https://hoodi.etherscan.io/address/0xD7c1B80fA86965B48cCA3aDcCB08E1DAEa291980) (proxy)
+- Lido and stETH token: [`0x2C220A2a91602dd93bEAC7b3A1773cdADE369ba1`](https://hoodi.etherscan.io/address/0x2C220A2a91602dd93bEAC7b3A1773cdADE369ba1) (proxy)
+- wstETH token: [`0x05F2927c5c2825BC0dCDc14d258a99A36116bE8B`](https://hoodi.etherscan.io/address/0x05F2927c5c2825BC0dCDc14d258a99A36116bE8B)
+- EIP-712 helper for stETH: [`0xBa4F7888A7Cb803776cc2f64b269a7cC7447cD1f`](https://hoodi.etherscan.io/address/0xBa4F7888A7Cb803776cc2f64b269a7cC7447cD1f)
+- Staking Router: [`0x7DE7173aeB9CDc06E429910104BD1e61a965f567`](https://hoodi.etherscan.io/address/0x7DE7173aeB9CDc06E429910104BD1e61a965f567) (proxy)
+- Execution Layer Rewards Vault: [`0x99137683D4AAfaf76C84bD8F6e2Ae6A95DF90912`](https://hoodi.etherscan.io/address/0x99137683D4AAfaf76C84bD8F6e2Ae6A95DF90912)
+- Withdrawal Queue (ERC‑721): [`0x07F941C56f155fA4233f0ed8d351C9Af3152E525`](https://hoodi.etherscan.io/address/0x07F941C56f155fA4233f0ed8d351C9Af3152E525) (proxy)
+- Withdrawal Vault: [`0x9659aAa1458E2dba8713018Ffa36c64048345901`](https://hoodi.etherscan.io/address/0x9659aAa1458E2dba8713018Ffa36c64048345901) (proxy)
+- Burner: [`0xa0f32368d67870f4864A748c910C7Ca9B99e1027`](https://hoodi.etherscan.io/address/0xa0f32368d67870f4864A748c910C7Ca9B99e1027)
+- Min First Allocation Strategy: [`0x4A08C1501a886861C17341317FF7885a5a1e5dB6`](https://hoodi.etherscan.io/address/0x4A08C1501a886861C17341317FF7885a5a1e5dB6)
+- Accounting: [`0x6adfFb27Dcc6b005988E4f9D408c877643D2d8A6`](https://hoodi.etherscan.io/address/0x6adfFb27Dcc6b005988E4f9D408c877643D2d8A6) (proxy)
+- Vault Hub: [`0x26b92f0fdfeBAf43E5Ea5b5974EeBee95F17Fe08`](https://hoodi.etherscan.io/address/0x26b92f0fdfeBAf43E5Ea5b5974EeBee95F17Fe08) (proxy)
+- Operator Grid: [`0x35dd33A473D492745eD5226Cf940b5b1ef4C111D`](https://hoodi.etherscan.io/address/0x35dd33A473D492745eD5226Cf940b5b1ef4C111D) (proxy)
+- Predeposit Guarantee: [`0xAcb99d36e19763C210A548019C6F238B67644417`](https://hoodi.etherscan.io/address/0xAcb99d36e19763C210A548019C6F238B67644417) (proxy)
+
+### 🔨 stVaults factory stack
+
+- Staking Vault Factory: [`0x74808E3Fe5B7714b580067Ab02032d19E0cD9f5f`](https://hoodi.etherscan.io/address/0x74808E3Fe5B7714b580067Ab02032d19E0cD9f5f)
+- Staking Vault Beacon: [`0x8de3b125221d07b44FCbd2CFD7354251858817B3`](https://hoodi.etherscan.io/address/0x8de3b125221d07b44FCbd2CFD7354251858817B3)
+- Staking Vault Implementation: [`0x5ff3782820Fc06cdF5a9ded897a778a6f0840b85`](https://hoodi.etherscan.io/address/0x5ff3782820Fc06cdF5a9ded897a778a6f0840b85)
+- Dashboard Implementation: [`0xcb3Bb848252F7ca05ED7753Ead0Eb2bdfD2ba878`](https://hoodi.etherscan.io/address/0xcb3Bb848252F7ca05ED7753Ead0Eb2bdfD2ba878)
+
+## 🔮 Oracle contracts
+
+- Accounting Oracle:
+  - AccountingOracle: [`0x43b319f67F9c48Ca76AA60d8693dc63E3B94698F`](https://hoodi.etherscan.io/address/0x43b319f67F9c48Ca76AA60d8693dc63E3B94698F) (proxy)
+  - Hash Consensus for Accounting Oracle: [`0x49C3eCB0F8C32a6F00be2848BE3Edb09Ef0646D9`](https://hoodi.etherscan.io/address/0x49C3eCB0F8C32a6F00be2848BE3Edb09Ef0646D9)
+- Validators Exit Bus Oracle:
+  - ValidatorsExitBusOracle: [`0xF1D059331C81C4ac9ACe81e3cE1a4961d59413f8`](https://hoodi.etherscan.io/address/0xF1D059331C81C4ac9ACe81e3cE1a4961d59413f8) (proxy)
+  - Hash Consensus for Validators Exit Bus Oracle: [`0xd7890f55266A795b59E9468Cd37a8524FBf44EFd`](https://hoodi.etherscan.io/address/0xd7890f55266A795b59E9468Cd37a8524FBf44EFd)
+- Oracle Report Sanity Checker: [`0x90F33A702E0DD5F050bA4910cCd3DC8b60C0901e`](https://hoodi.etherscan.io/address/0x90F33A702E0DD5F050bA4910cCd3DC8b60C0901e)
+- Oracle Daemon Config: [`0x2cB903dA5DB2Ad46E367F32499fB2781E0D2eD7D`](https://hoodi.etherscan.io/address/0x2cB903dA5DB2Ad46E367F32499fB2781E0D2eD7D)
+
+## 🗳️ DAO & Aragon apps
+
+- Lido DAO (Kernel): [`0x207BAA2a636f094eCCBaA70FDE74D31723b7709c`](https://hoodi.etherscan.io/address/0x207BAA2a636f094eCCBaA70FDE74D31723b7709c) (proxy)
+- LDO token: [`0xbfd40Db0a3CB72cF936353CE4EA6cdbBeB65F1Db`](https://hoodi.etherscan.io/address/0xbfd40Db0a3CB72cF936353CE4EA6cdbBeB65F1Db)
+- Aragon Voting: [`0x3DF09262F937a92b9d7CC020e22709b6c6641d7d`](https://hoodi.etherscan.io/address/0x3DF09262F937a92b9d7CC020e22709b6c6641d7d) (proxy)
+- Aragon Token Manager: [`0xB769867675CD2e3c2ea7b29b5Bd282dC1C00Ad66`](https://hoodi.etherscan.io/address/0xB769867675CD2e3c2ea7b29b5Bd282dC1C00Ad66) (proxy)
+- Aragon Finance: [`0x86eAE4CBb13e5d7f8f4a3582F24F6133047672F2`](https://hoodi.etherscan.io/address/0x86eAE4CBb13e5d7f8f4a3582F24F6133047672F2) (proxy)
+- Aragon Agent: [`0xEB9712bf5DD2179EEacc45A62A69b156299084a7`](https://hoodi.etherscan.io/address/0xEB9712bf5DD2179EEacc45A62A69b156299084a7) (proxy)
+- Aragon ACL: [`0xF55a0c7Da6932eBd859Bd7AE896757959785340e`](https://hoodi.etherscan.io/address/0xF55a0c7Da6932eBd859Bd7AE896757959785340e) (proxy)
+
+## 🧩 Staking modules
+
+### Curated Module
+
+- Node Operators Registry: [`0xa38DE5874E81561F29cfa4436111852CC34aC1e1`](https://hoodi.etherscan.io/address/0xa38DE5874E81561F29cfa4436111852CC34aC1e1) (proxy)
+
+### Simple DVT Module
+
+- Simple DVT: [`0x0718D0A48D9B3Fd6E03B10249655539DB4Bf63c4`](https://hoodi.etherscan.io/address/0x0718D0A48D9B3Fd6E03B10249655539DB4Bf63c4) (proxy)
+
+## Easy Track
+
+- EasyTrack: [`0x9A2029735Bd14C8b17fd03FE05D5F04F7AF797c2`](https://hoodi.etherscan.io/address/0x9A2029735Bd14C8b17fd03FE05D5F04F7AF797c2)
+- EVMScriptExecutor: [`0x0b6de69562CADa4dBFdCA7e448fdc71D3542A590`](https://hoodi.etherscan.io/address/0x0b6de69562CADa4dBFdCA7e448fdc71D3542A590)
+
+## ⛏️ Special accounts and addresses
+
+<details>
+<summary>Show/hide</summary>
+
+| Contract                           | Address                                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Deposit Security Module (EOA stub) | [`0xfF772cd178D04F0B4b1EFB730c5F2B9683B31611`](https://hoodi.etherscan.io/address/0xfF772cd178D04F0B4b1EFB730c5F2B9683B31611) |
+| Deployer (EOA)                     | [`0x26EDb7f0f223A25EE390aCCccb577F3a31edDfC5`](https://hoodi.etherscan.io/address/0x26EDb7f0f223A25EE390aCCccb577F3a31edDfC5) |
+
+</details>
+
+---
+
+:::caution
+🧪 Testnet use only
+stETH obtained on this network **has no real ETH backing** and **cannot** be bridged, swapped or redeemed on mainnet. Please do _not_ send mainnet tokens here – they will be lost forever.
+:::
+
+<details>
+<summary>testnet-1 (archive)</summary>
 
 ## 🏛️ Core protocol
 
@@ -90,16 +176,13 @@ Take 30 s to drop your thoughts through **[this quick form](https://tally.so/r
 <details>
 <summary>Show/hide</summary>
 
-| Contract | Address |
-|---|---|
+| Contract                           | Address                                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | Deposit Security Module (EOA stub) | [`0xfF772cd178D04F0B4b1EFB730c5F2B9683B31611`](https://hoodi.etherscan.io/address/0xfF772cd178D04F0B4b1EFB730c5F2B9683B31611) |
-| Deployer (EOA) | [`0x26EDb7f0f223A25EE390aCCccb577F3a31edDfC5`](https://hoodi.etherscan.io/address/0x26EDb7f0f223A25EE390aCCccb577F3a31edDfC5) |
+| Deployer (EOA)                     | [`0x26EDb7f0f223A25EE390aCCccb577F3a31edDfC5`](https://hoodi.etherscan.io/address/0x26EDb7f0f223A25EE390aCCccb577F3a31edDfC5) |
 
 </details>
 
 ---
 
-:::caution
-🧪 Testnet use only
-stETH obtained on this network **has no real ETH backing** and **cannot** be bridged, swapped or redeemed on mainnet. Please do *not* send mainnet tokens here – they will be lost forever.
-:::
+</details>


### PR DESCRIPTION
## Summary
- refresh Hoodi addresses to new testnet-2 deployment
- keep previous testnet-1 addresses under an archive section

## Testing
- `npx prettier -w docs/deployed-contracts/hoodi-lidov3.md`


------
https://chatgpt.com/codex/tasks/task_b_68519da812d8832baa055cafa7fdedff