### PR TITLE
Fix: Make Hoodi to be the primary testnet

### DIFF
--- a/docs/deployed-contracts/holesky.md
+++ b/docs/deployed-contracts/holesky.md
@@ -1,7 +1,8 @@
 # Holešky
 
 :::warning
-Currently, the main operational and maintained protocol testnet is being migrated from [Holešky](/deployed-contracts/holesky.md) to [Hoodi](/deployed-contracts/hoodi.md).
+The **Holešky** deployment is now fully **deprecated**.  
+Please use the [**Hoodi**](/deployed-contracts/hoodi.md) deployment instead.
 :::
 
 ## Core protocol

--- a/docs/deployed-contracts/hoodi.md
+++ b/docs/deployed-contracts/hoodi.md
@@ -1,7 +1,7 @@
 # Hoodi
 
-:::warning
-Currently, the main operational and maintained protocol testnet is being migrated from [Holešky](/deployed-contracts/holesky.md) to [Hoodi](/deployed-contracts/hoodi.md).
+:::info
+Hoodi is the main operational and maintained protocol testnet.
 :::
 
 ## Core protocol

--- a/docs/deployed-contracts/sepolia.md
+++ b/docs/deployed-contracts/sepolia.md
@@ -4,7 +4,7 @@
 Sepolia testnet has only a limited set of working parts of the protocol.
 
 For instance, the in-protocol [withdrawals](/docs/contracts/withdrawal-queue-erc721.md) aren't available
-(paused indefinitely), please use the [Holešky testnet](/deployed-contracts/holesky.md) deployment if possible.
+(paused indefinitely), please use the [Hoodi testnet](/deployed-contracts/hoodi.md) deployment if possible.
 
 The goals for this testnet deployment are:
 


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Hoodi is the main testnet now
2. Holešky is deprecated
