### PR TITLE
fix: update IPFS links to use inbrowser.link for Lido applications

### DIFF
--- a/docs/ipfs/apps-list.md
+++ b/docs/ipfs/apps-list.md
@@ -4,7 +4,7 @@ This page is a source of up-to-date hashes of Lido applications deployed to the 
 
 - Lido Ethereum Liquid Staking Widget:
   - Release: [0.76.1](https://github.com/lidofinance/ethereum-staking-widget/releases/tag/0.76.1)
-  - CID: [`bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u`](https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.dweb.link)
+  - CID: [`bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u`](https://bafybeiecvujvs74xvxgpwctmbfkcucazyaudmwuiw4wfv6ys7uio7o376u.ipfs.inbrowser.link/)
 - stETH as Anchor collateral widget:
   - Release: 0.24.0
-  - CID: [`bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha`](https://bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha.ipfs.dweb.link)
+  - CID: [`bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha`](https://bafybeibm56vtc6bgj2emrcz5que3lr4w3crsbc77h7trtceezpcp2rpoha.ipfs.inbrowser.link)


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
This pull request updates the IPFS gateway URLs in the `docs/ipfs/apps-list.md` documentation. The links for the Lido Ethereum Liquid Staking Widget and the stETH as Anchor collateral widget now use the `ipfs.inbrowser.link` gateway instead of `ipfs.dweb.link`.

### 🔎 Attach a source of truth or evidence that allows reviewers to confirm the changes independently
1. 
