### PR TITLE
Update composition of RMC committee 

### DIFF
--- a/docs/multisigs/committees.md
+++ b/docs/multisigs/committees.md
@@ -107,13 +107,13 @@ The full list of related contracts is available [here](https://docs.lido.fi/depl
 
 | Name | Address | Verification | Public verification |
 | --- | --- | --- | --- |
-| Izzy | 0x783EA934d543CD1ccfd920639A7539a0BD3895e2 | https://etherscan.io/verifySig/12775 | https://twitter.com/IsdrsP/status/1602973286534680577 |
 | George | 0x912e21CdA3D7012146da4Df33309d860a9eb0bEb | https://etherscan.io/verifySig/17866 | https://twitter.com/george_avs/status/1602229253696790528 |
 | eliasimos | 0x4981a4775983e947b12d0982021bea8697175f4a | Sig hash: 0x67291ff9224b8ebfd217ff00d5f1eefceacdd1fe2916b0b1a2157169d813ac9c099ce5d926c2b16252abc89fc7df21d1efa07e1e0b1d7497f454ff340920d23e01 | https://twitter.com/eliasimos/status/1602924642645282816?s=20&t=_dSkjtTQhkyjM2kVdpEZbA |
-| yorickdowne | 0xeCbb058Fc429941124a2b8d0984354c3132F536f | https://etherscan.io/verifySig/12686 | https://twitter.com/yorickdowne/status/1601284004631941120?s=20&t=Qv2CBYDSEtNaWBIdQtKvYQ |
 | michaelsprou | 0x6B29132ea388a308578c1d3Be068D0e4fc9915a2 | https://gist.github.com/michaelsproul/677cf9abb2789e61973662868f8bd29d | https://twitter.com/sproulM_/status/1602519592026382337 |
 | philknows | 0x0ef5c6Ab0C44b2b042606215530437809eFE54c8 | https://etherscan.io/verifySig/12760 | https://twitter.com/philngo_/status/1602781428114411520?s=20&t=Q2XjlHIwayyTdVNoKQshig |
 | Dharmendra | 0x2d0669db84f11a9ead41e57ce2f242d92111a58f | https://etherscan.io/verifySig/17652 | https://twitter.com/DharmendraKari3/status/1653844633921916931?s=20 |
+| Sven | 0x215b5f40b6507d8398a23af4d92a1aeeb6457901 | https://etherscan.io/verifySig/279163 | https://x.com/SvenBrekelmans/status/1961034505671561229 |
+| Mario | 0xBC621E0fAd141CD1b14f34f7954695E6C3322472 | https://etherscan.io/verifySig/279564 | https://x.com/Mario782674/status/1963207911531843615 |
 
 ## 2.4 Token Reward Program (TRP) Association Multisig
 


### PR DESCRIPTION
Update the composition of the RMC committee (List of Signers) after rotating out Izzy for Sven and and Yorick/Thorsten for Mario. 

**Based on forum proposals:** 

https://research.lido.fi/t/lido-on-ethereum-identify-and-constitute-relay-maintenance-committee/3386/21?u=sven

**Multisig rotation executed in this transaction:** 
https://app.safe.global/transactions/tx?safe=eth:0x98be4a407bff0c125e25fbe9eb1165504349c37d&id=multisig_0x98be4a407Bff0c125e25fBE9Eb1165504349c37d_0x68a85ced51582e80dbfbec1b6d67e4404ac7e4531ed1bc2369c1866a37c8bcf0

**The rotations:**(can be confirmed on forum and in transaction)
   - Izzy (0x783EA934d543CD1ccfd920639A7539a0BD3895e2) -> Sven (`0x215b5f40b6507d8398a23af4d92a1aeeb6457901`)
   - Thorsten ( 0xeCbb058Fc429941124a2b8d0984354c3132F536f) -> Mario (`0xBC621E0fAd141CD1b14f34f7954695E6C3322472`)