### PR TITLE
feat: Oracle v6 release

### DIFF
--- a/docs/guides/oracle-operator-manual.md
+++ b/docs/guides/oracle-operator-manual.md
@@ -102,21 +102,11 @@ graph LR;
 
 ## Committee membership
 
-The current Oracle set consists of 9 participants:
+The current Oracle set consists of 9 participants with a quorum of 5. This means that report finalization can only occur when there are 5 identical reports from 5 different oracle members.
 
-- Chorus One [0x285f8537e1daeedaf617e96c742f2cf36d63ccfb](https://research.lido.fi/t/emergency-rotation-of-compromised-chorus-one-oracle/10037/2)
-- Staking Facilities `0x404335bce530400a5814375e7ec1fb55faff3ea2`
-- stakefish `0x946d3b081ed19173dc83cd974fc69e1e760b7d78`
-- P2P Validator `0x007de4a5f7bc37e2f26c0cb2e8a95006ee9b89b5`
-- bloXroute [0x61c91ECd902EB56e314bB2D5c5C07785444Ea1c8](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836/54)
-- Instadapp [0x73181107c8D9ED4ce0bbeF7A0b4ccf3320C41d12](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836/71)
-- Caliber [0x4118dad7f348a4063bd15786c299de2f3b1333f3](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836/78)
-- ChainLayer [0xc79F702202E3A6B0B6310B537E786B9ACAA19BAf](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836/69)
-- Matrixed.Link [0xe57B3792aDCc5da47EF4fF588883F0ee0c9835C9](https://research.lido.fi/t/rated-labs-replacement-in-the-oracle-set/7850/14)
+The actual list of Oracle participants list can be fetched from the HashConsensus contract using the [`getMembers`](https://etherscan.io/address/0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288#readContract#F16) method.
 
-The quorum is 5/9. This means that the report finalization can only occur when there are 5 identical reports from the 5 different oracle members.
-
-See [Expansion of Lido on Ethereum Oracle set](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836) post for more details.
+The latest updates can be found in the [Expansion of Lido on Ethereum Oracle set](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836) post.
 
 ## Prerequisites
 

--- a/docs/guides/oracle-operator-manual.md
+++ b/docs/guides/oracle-operator-manual.md
@@ -105,6 +105,7 @@ graph LR;
 The current Oracle set consists of 9 participants with a quorum of 5. This means that report finalization can only occur when there are 5 identical reports from 5 different oracle members.
 
 The actual list of Oracle participants list can be fetched from the HashConsensus contract using the [`getMembers`](https://etherscan.io/address/0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288#readContract#F16) method.
+*Hoodi Oracle participants' addresses can be found [here](https://hoodi.etherscan.io/address/0x32EC59a78abaca3f91527aeB2008925D5AaC1eFC#readContract#F16)*
 
 The latest updates can be found in the [Expansion of Lido on Ethereum Oracle set](https://research.lido.fi/t/expansion-of-lidos-ethereum-oracle-set/2836) post.
 

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -9,7 +9,7 @@ Oracle daemon for Lido decentralized staking service.
 - **Version**: 6.0.1
 - **Docker image**: sha256:f7d5f06c0b5774f09d85578a42a155cbcacdc305e0c5572ed7eaa8a6769d4077, [lidofinance/oracle@sha256-f7d5f06c0b5774f09d85578a42a155cbcacdc305e0c5572ed7eaa8a6769d4077](https://hub.docker.com/layers/lidofinance/oracle/6.0.1/images/sha256-f7d5f06c0b5774f09d85578a42a155cbcacdc305e0c5572ed7eaa8a6769d4077)
 - **Commit hash**: [lidofinance/lido-oracle@54434f4](https://github.com/lidofinance/lido-oracle/commit/54434f46ab6681785451db88d03677036e4dd07b)
-- **Last update date**: 20 Aug, 2025
+- **Last update date**: 18 September, 2025
 - [**Repository**](https://github.com/lidofinance/lido-oracle/tree/6.0.1)
 - [**Documentation**](/guides/oracle-operator-manual)
 - [**Audit Report**](https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20V6%20Audit%20Report.pdf)

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -6,15 +6,13 @@ Summary of tooling used in Lido V2: Oracle, Validator Ejector, Council Daemon, a
 
 Oracle daemon for Lido decentralized staking service.
 
-- **Version**: 5.4.1
-- **Docker image**: sha256:db0d00468df9840aa4084485314911a030c39c57da80656e92152883b2da6566, [lidofinance/oracle@sha256-db0d00468df9840aa4084485314911a030c39c57da80656e92152883b2da6566](https://hub.docker.com/layers/lidofinance/oracle/5.4.1/images/sha256-db0d00468df9840aa4084485314911a030c39c57da80656e92152883b2da6566)
-- **Commit hash**: [lidofinance/lido-oracle@f17f089](https://github.com/lidofinance/lido-oracle/commit/f17f0898cd8c46eefba5da0ad3162dc2f4bcf439)
+- **Version**: 6.0.1
+- **Docker image**: sha256:f7d5f06c0b5774f09d85578a42a155cbcacdc305e0c5572ed7eaa8a6769d4077, [lidofinance/oracle@sha256-f7d5f06c0b5774f09d85578a42a155cbcacdc305e0c5572ed7eaa8a6769d4077](https://hub.docker.com/layers/lidofinance/oracle/6.0.1/images/sha256-f7d5f06c0b5774f09d85578a42a155cbcacdc305e0c5572ed7eaa8a6769d4077)
+- **Commit hash**: [lidofinance/lido-oracle@54434f4](https://github.com/lidofinance/lido-oracle/commit/54434f46ab6681785451db88d03677036e4dd07b)
 - **Last update date**: 20 Aug, 2025
-- [**Repository**](https://github.com/lidofinance/lido-oracle/tree/5.4.1)
+- [**Repository**](https://github.com/lidofinance/lido-oracle/tree/6.0.1)
 - [**Documentation**](/guides/oracle-operator-manual)
-- [**Audit 1**](https://github.com/lidofinance/audits/blob/main/MixBytes%20Lido%20Oracle%20v5%2004-25.pdf)
-- [**Audit 2**](https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20v5%2004-25.pdf)
-- [**Audit 3**](https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20V5_4_1%2008-25.pdf)
+- [**Audit Report**](https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20V6%20Audit%20Report.pdf)
 
 ## Validator Ejector
 


### PR DESCRIPTION
## Please, go through these steps before you request a review:

Oracle V6 review. 
All hashes could be checked in Composable Security audit report.

Removed participants list because it's outdated