### PR TITLE
fix: replace icon on RunOnLido-page

### DIFF
--- a/run-on-lido/intro.md
+++ b/run-on-lido/intro.md
@@ -7,6 +7,6 @@ sidebar_position: 0
 This section of the Lido documentation is for users who want to run any of the Lido products, whether Node Operators, Vault owners, or Oracle Operators.
 
 &emsp;🖥️ Learn how to set up a CSM Operator with the [Community Staking Module](/run-on-lido/csm/)  
-&emsp;🕋 Discover how to build staking products powered by [stVaults](/run-on-lido/stvaults/)  
+&emsp;🔲 Discover how to build staking products powered by [stVaults](/run-on-lido/stvaults/)  
 &emsp;📄 See the protocol documentation, contracts and more in the [main section of the docs](/)  
 &emsp;🤝 Find support and community on [Discord](https://discord.gg/vgdPfhZ), [Telegram](https://t.me/lidofinance)


### PR DESCRIPTION
Replace the wrong icon on the Run on Lido page