### PR TITLE
chore: bump core contracts to v3.0.2

### DIFF
--- a/docs/contracts/accounting-oracle.md
+++ b/docs/contracts/accounting-oracle.md
@@ -1,8 +1,8 @@
 # AccountingOracle
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/oracle/AccountingOracle.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/oracle/AccountingOracle.sol)
 - [Deployed contract](https://etherscan.io/address/0x852deD011285fe67063a08005c71a85690503Cee)
-- Inherits [BaseOracle](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/oracle/BaseOracle.sol)
+- Inherits [BaseOracle](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/oracle/BaseOracle.sol)
 
 :::info
 It's advised to read [What is Lido Oracle mechanism](/guides/oracle-operator-manual#intro) before
@@ -234,7 +234,7 @@ Extra data array can be passed in different formats, see below.
 ## Access and permissions
 
 Access to lever methods is restricted using the functionality of the
-[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
+[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
 contract and a bunch of [granular roles](#permissions).
 
 ## Constants

--- a/docs/contracts/accounting.md
+++ b/docs/contracts/accounting.md
@@ -1,6 +1,6 @@
 # Accounting
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/Accounting.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/Accounting.sol)
 - [Deployed contract](https://etherscan.io/address/0x23ED611be0e1a820978875C0122F92260804cdDf)
 
 Handles oracle reports and calculates protocol state changes including rebases, fee distribution, and stVault bad debt internalization.

--- a/docs/contracts/burner.md
+++ b/docs/contracts/burner.md
@@ -1,6 +1,6 @@
 # Burner
 
-- [Source Code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/Burner.sol)
+- [Source Code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/Burner.sol)
 - [Deployed Contract](https://etherscan.io/address/0xE76c52750019b80B43E36DF30bf4060EB73F573a)
 
 The contract provides a way for Lido protocol to burn stETH token shares as a means to finalize withdrawals,

--- a/docs/contracts/dashboard.md
+++ b/docs/contracts/dashboard.md
@@ -1,6 +1,6 @@
 # Dashboard
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/dashboard/Dashboard.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/dashboard/Dashboard.sol)
 - [Implementation](https://etherscan.io/address/0x294825c2764c7D412dc32d87E2242c4f1D989AF3)
 
 Management contract for stVaults. Provides role-based control for vault operations and convenience wrappers for minting/burning stETH and wstETH. Individual Dashboard instances are deployed as proxies by [VaultFactory](/contracts/staking-vault-factory).

--- a/docs/contracts/deposit-security-module.md
+++ b/docs/contracts/deposit-security-module.md
@@ -1,6 +1,6 @@
 # DepositSecurityModule
 
-- [Source Code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/DepositSecurityModule.sol)
+- [Source Code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/DepositSecurityModule.sol)
 - [Deployed Contract](https://etherscan.io/address/0xfFA96D84dEF2EA035c7AB153D8B991128e3d72fD)
 
 Due to front-running vulnerability, Lido contributors [proposed](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-5.md) to establish the Deposit Security Committee dedicated to ensuring the safety of deposits on the Beacon chain:

--- a/docs/contracts/eip712-steth.md
+++ b/docs/contracts/eip712-steth.md
@@ -1,6 +1,6 @@
 # EIP712StETH
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/EIP712StETH.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/EIP712StETH.sol)
 - [Deployed contract](https://etherscan.io/address/0x8F73e4C2A6D852bb4ab2A45E6a9CF5715b3228B7)
 
 `EIP712StETH` serves as a dedicated helper contract for `stETH`, crucial for the complete support of [ERC-2612 compliant signed approvals](https://eips.ethereum.org/EIPS/eip-2612).
@@ -36,7 +36,7 @@ function hashTypedDataV4(address _stETH, bytes32 _structHash) returns (bytes32)
 | `_stETH`      | `address` | Address of the deployed `stETH` token |
 | `_structHash` | `bytes32` | Hash of the data structure            |
 
-For a specific use case, see the [StETHPermit.permit()](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.4.24/StETHPermit.sol#L99-L112) implementation.
+For a specific use case, see the [StETHPermit.permit()](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.4.24/StETHPermit.sol#L99-L112) implementation.
 
 ### eip712Domain()
 

--- a/docs/contracts/hash-consensus.md
+++ b/docs/contracts/hash-consensus.md
@@ -1,6 +1,6 @@
 # HashConsensus
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/oracle/HashConsensus.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/oracle/HashConsensus.sol)
 - [Deployed instance for AccountingOracle](https://etherscan.io/address/0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288)
 - [Deployed instance for ValidatorsExitBusOracle](https://etherscan.io/address/0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a)
 - [Deployed instance for CSFeeOracle](https://etherscan.io/address/0x71093efF8D8599b5fA340D665Ad60fA7C80688e4)

--- a/docs/contracts/lazy-oracle.md
+++ b/docs/contracts/lazy-oracle.md
@@ -1,6 +1,6 @@
 # LazyOracle
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/LazyOracle.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/LazyOracle.sol)
 - [Deployed contract](https://etherscan.io/address/0x5DB427080200c235F2Ae8Cd17A7be87921f7AD6c)
 
 Oracle adapter for stVaults. Stores per-vault reports, applies sanity checks, and forwards vault updates to VaultHub.

--- a/docs/contracts/lido-execution-layer-rewards-vault.md
+++ b/docs/contracts/lido-execution-layer-rewards-vault.md
@@ -1,6 +1,6 @@
 # LidoExecutionLayerRewardsVault
 
-- [Source Code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/LidoExecutionLayerRewardsVault.sol)
+- [Source Code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/LidoExecutionLayerRewardsVault.sol)
 - [Deployed Contract](https://etherscan.io/address/0x388C818CA8B9251b393131C08a736A67ccB19297)
 
 A vault for temporary storage of execution layer (EL) rewards (MEV and tx priority fee).

--- a/docs/contracts/lido-locator.md
+++ b/docs/contracts/lido-locator.md
@@ -1,6 +1,6 @@
 # LidoLocator
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/LidoLocator.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/LidoLocator.sol)
 - [Deployed contract](https://etherscan.io/address/0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb)
 
 LidoLocator is the universal address book for the Lido protocol.

--- a/docs/contracts/lido.md
+++ b/docs/contracts/lido.md
@@ -1,6 +1,6 @@
 # Lido
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.4.24/Lido.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.4.24/Lido.sol)
 - [Deployed contract](https://etherscan.io/address/0xae7ab96520de3a18e5e111b5eaab095312d7fe84)
 
 Liquid staking pool and a related [ERC-20](https://eips.ethereum.org/EIPS/eip-20)

--- a/docs/contracts/node-operators-registry.md
+++ b/docs/contracts/node-operators-registry.md
@@ -4,7 +4,7 @@
 - [Deployed Contract](https://etherscan.io/address/0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5)
 
 The `NodeOperatorsRegistry` contract acts as a registry of Node Operators selected by the Lido DAO.
-Since [Lido V2 upgrade](https://blog.lido.fi/introducing-lido-v2/) `NodeOperatorsRegistry` contract became a module of [`StakingRouter`](/contracts/staking-router) and got the second name **Curated staking module** as part of the general Lido staking infrastructure. As a staking module, `NodeOperatorsRegistry` implements [StakingModule interface](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/interfaces/IStakingModule.sol).
+Since [Lido V2 upgrade](https://blog.lido.fi/introducing-lido-v2/) `NodeOperatorsRegistry` contract became a module of [`StakingRouter`](/contracts/staking-router) and got the second name **Curated staking module** as part of the general Lido staking infrastructure. As a staking module, `NodeOperatorsRegistry` implements [StakingModule interface](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/interfaces/IStakingModule.sol).
 
 `NodeOperatorsRegistry` keeps track of various Node Operators data, in particular limits of the allowed stake, reward addresses, penalty information, public keys of the Node Operators' validators. It defines order in which the Node Operators get the ether deposited and reward distribution between the node operators.
 

--- a/docs/contracts/operator-grid.md
+++ b/docs/contracts/operator-grid.md
@@ -1,6 +1,6 @@
 # OperatorGrid
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/OperatorGrid.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/OperatorGrid.sol)
 - [Deployed contract](https://etherscan.io/address/0xC69685E89Cefc327b43B7234AC646451B27c544d)
 
 Registry for node operators, groups, and tier parameters that define share limits, reserve ratios, and fee schedules for stVaults.

--- a/docs/contracts/oracle-daemon-config.md
+++ b/docs/contracts/oracle-daemon-config.md
@@ -1,6 +1,6 @@
 # OracleDaemonConfig
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/OracleDaemonConfig.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/OracleDaemonConfig.sol)
 - [Deployed contract](https://etherscan.io/address/0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09)
 
 OracleDaemonConfig acts as a parameters registry for the Lido oracle daemon.

--- a/docs/contracts/oracle-report-sanity-checker.md
+++ b/docs/contracts/oracle-report-sanity-checker.md
@@ -1,6 +1,6 @@
 # OracleReportSanityChecker
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/sanity_checks/OracleReportSanityChecker.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/sanity_checks/OracleReportSanityChecker.sol)
 - [Deployed contract](https://etherscan.io/address/0xf1647c86E6D7959f638DD9CE1d90e2F3C9503129)
 
 Some vital data for the Lido protocol is collected off-chain and delivered on-chain via Oracle contracts:
@@ -15,7 +15,7 @@ Besides the validation methods, the `OracleReportSanityChecker` contract contain
 used during the report validation process.
 To configure the limits values contract provides the lever methods described in the [standalone section](#lever-methods).
 Access to lever methods is restricted using the functionality of the
-[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
+[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
 contract and a bunch of [granular roles](#permissions).
 
 ## Limits List

--- a/docs/contracts/ossifiable-proxy.md
+++ b/docs/contracts/ossifiable-proxy.md
@@ -1,6 +1,6 @@
 # OssifiableProxy
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/proxy/OssifiableProxy.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/proxy/OssifiableProxy.sol)
 - [Source code of `WithdrawalsManagerProxy`](https://github.com/lidofinance/withdrawals-manager-stub/blob/main/contracts/WithdrawalsManagerProxy.sol)
 
 Deployed instances:

--- a/docs/contracts/predeposit-guarantee.md
+++ b/docs/contracts/predeposit-guarantee.md
@@ -1,6 +1,6 @@
 # PredepositGuarantee
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol)
 - [Deployed contract](https://etherscan.io/address/0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3)
 
 PredepositGuarantee (PDG) mitigates deposit frontrunning by requiring a node operator guarantee and validator withdrawal credentials proofs (EIP-4788) before activating staged deposits.

--- a/docs/contracts/staking-router.md
+++ b/docs/contracts/staking-router.md
@@ -1,6 +1,6 @@
 # StakingRouter
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/StakingRouter.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/StakingRouter.sol)
 - [Deployed contract](https://etherscan.io/address/0xFdDf38947aFB03C621C71b06C9C70bce73f12999)
 
 StakingRouter is a registry of staking modules, each encapsulating a certain validator subset, e.g. the Lido DAO-curated staking module. The contract allocates stake to modules, distributes protocol fees, and tracks relevant information.
@@ -70,7 +70,7 @@ The `deposit` function begins by verifying the sender's identity and checking th
 
 The algorithm used for the allocation process is designed to consider various factors, including the limit of deposits per transaction, the quantity of ether ready for deposit, the active and available keys within each module, and each module's target share. It then estimates the maximum deposit based on these parameters. The algorithm also identifies the key limits for all modules, and initiates the allocation of keys, starting with the module that has the least active keys. This continues until there is no more ether to allocate or when all the modules have reached their capacity. At the end of the process, any remaining ether is returned.
 
-The allocation function uses the [`MinFirstAllocationStrategy`](https://github.com/lidofinance/core/blob/v3.0.1/contracts/common/lib/MinFirstAllocationStrategy.sol) algorithm to allocate new deposits among different staking modules.
+The allocation function uses the [`MinFirstAllocationStrategy`](https://github.com/lidofinance/core/blob/v3.0.2/contracts/common/lib/MinFirstAllocationStrategy.sol) algorithm to allocate new deposits among different staking modules.
 
 Here is a breakdown of the process:
 

--- a/docs/contracts/staking-vault-factory.md
+++ b/docs/contracts/staking-vault-factory.md
@@ -1,6 +1,6 @@
 # VaultFactory
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/VaultFactory.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/VaultFactory.sol)
 - [Deployed contract](https://etherscan.io/address/0x02Ca7772FF14a9F6c1a08aF385aA96bb1b34175A)
 
 Factory for deploying `StakingVault` + `Dashboard` pairs using a beacon proxy.

--- a/docs/contracts/staking-vault.md
+++ b/docs/contracts/staking-vault.md
@@ -1,6 +1,6 @@
 # StakingVault
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/StakingVault.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/StakingVault.sol)
 - [Implementation](https://etherscan.io/address/0x06A56487494aa080deC7Bf69128EdA9225784553)
 - [Beacon](https://etherscan.io/address/0x5FbE8cEf9CCc56ad245736D3C5bAf82ad54Ca789)
 

--- a/docs/contracts/triggerable-withdrawals-gateway.md
+++ b/docs/contracts/triggerable-withdrawals-gateway.md
@@ -1,6 +1,6 @@
 # TriggerableWithdrawalsGateway
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/TriggerableWithdrawalsGateway.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/TriggerableWithdrawalsGateway.sol)
 - [Deployed contract](https://etherscan.io/address/0xDC00116a0D3E064427dA2600449cfD2566B3037B)
 - Specification basis: [LIP-30 — Triggerable withdrawals](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-30.md)
 
@@ -11,7 +11,7 @@ TriggerableWithdrawalsGateway (TWG) is a gateway contract introducing an validat
 ## Roles and access control
 
 Access to lever methods is restricted using the functionality of the
-[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
+[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
 contract and a bunch of [granular roles](#permissions).
 To engage Emergency Brakes and unpause if required, it inherits from `PausableContract` (see [GateSeals](https://docs.lido.fi/contracts/gate-seal)).
 

--- a/docs/contracts/validator-consolidation-requests.md
+++ b/docs/contracts/validator-consolidation-requests.md
@@ -1,6 +1,6 @@
 # ValidatorConsolidationRequests
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/ValidatorConsolidationRequests.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/ValidatorConsolidationRequests.sol)
 - [Deployed contract](https://etherscan.io/address/0xaC4Aae7123248684C405A4b0038C1560EC7fE018)
 
 Helper contract that builds calldata for validator consolidation requests (EIP-7251) into stVaults and exposes the current consolidation fee.

--- a/docs/contracts/validator-exit-delay-verifier.md
+++ b/docs/contracts/validator-exit-delay-verifier.md
@@ -1,6 +1,6 @@
 # ValidatorExitDelayVerifier
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/ValidatorExitDelayVerifier.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/ValidatorExitDelayVerifier.sol)
 - [Deployed contract](https://etherscan.io/address/0xbDb567672c867DB533119C2dcD4FB9d8b44EC82f)
 
 ## What is ValidatorExitDelayVerifier

--- a/docs/contracts/validators-exit-bus-oracle.md
+++ b/docs/contracts/validators-exit-bus-oracle.md
@@ -1,9 +1,9 @@
 # ValidatorsExitBusOracle
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol)
 - [Deployed contract](https://etherscan.io/address/0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e)
 - Inherits [VEB](https://github.com/lidofinance/core/blob/master/contracts/0.8.9/oracle/ValidatorsExitBus.sol)
-- Inherits [BaseOracle](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/oracle/BaseOracle.sol)
+- Inherits [BaseOracle](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/oracle/BaseOracle.sol)
 
 :::info
 It's advised to read [What is Lido Oracle mechanism](/guides/oracle-operator-manual#intro) before
@@ -21,7 +21,7 @@ Placed exit requests via `ValidatorsExitBusOracle` should be processed timely ac
 :::
 
 Access to privileged methods is restricted using the functionality of the
-[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
+[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
 contract and a bunch of [granular roles](#permissions).
 
 ## Report cycle

--- a/docs/contracts/vault-hub.md
+++ b/docs/contracts/vault-hub.md
@@ -1,6 +1,6 @@
 # VaultHub
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/vaults/VaultHub.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/vaults/VaultHub.sol)
 - [Deployed contract](https://etherscan.io/address/0x1d201BE093d847f6446530Efb0E8Fb426d176709)
 
 Central registry and lifecycle manager for StakingVaults connected to the Lido protocol. Handles vault connection, minting/burning stETH against vault collateral, rebalancing, fee settlement, and bad debt management.
@@ -19,7 +19,7 @@ VaultHub is the coordinator between individual StakingVaults and the Lido protoc
 
 ## Inherits
 
-- [PausableUntilWithRoles](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.25/utils/PausableUntilWithRoles.sol)
+- [PausableUntilWithRoles](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.25/utils/PausableUntilWithRoles.sol)
 
 ## Constants
 

--- a/docs/contracts/withdrawal-queue-erc721.md
+++ b/docs/contracts/withdrawal-queue-erc721.md
@@ -1,12 +1,12 @@
 # WithdrawalQueueERC721
 
-- [Source code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/WithdrawalQueueERC721.sol)
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/WithdrawalQueueERC721.sol)
 - [Deployed contract](https://etherscan.io/address/0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1)
 
 A FIFO queue for `stETH` withdrawal requests and an `unstETH` NFT implementation representing the position in the queue.
 
 Access to lever methods is restricted using the functionality of the
-[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
+[AccessControlEnumerable](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/utils/access/AccessControlEnumerable.sol)
 contract and a bunch of [granular roles](#roles).
 
 ## What is WithdrawalQueueERC721?

--- a/docs/contracts/withdrawal-vault.md
+++ b/docs/contracts/withdrawal-vault.md
@@ -1,6 +1,6 @@
 # WithdrawalVault
 
-- [Source Code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.8.9/WithdrawalVault.sol)
+- [Source Code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.8.9/WithdrawalVault.sol)
 - [Deployed Contract](https://etherscan.io/address/0xb9d7934878b5fb9610b3fe8a5e441e8fad7e293f)
 - Inherits [WithdrawalVaultEIP7002](https://github.com/lidofinance/core/blob/master/contracts/0.8.9/WithdrawalVaultEIP7002.sol). Interface that implements basic EIP-7002 functionality.
 

--- a/docs/contracts/wsteth.md
+++ b/docs/contracts/wsteth.md
@@ -1,6 +1,6 @@
 # wstETH
 
-- [Source Code](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.6.12/WstETH.sol)
+- [Source Code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.6.12/WstETH.sol)
 - [Deployed Contract](https://etherscan.io/token/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0)
 
 ## What is wrapped stETH (wstETH)?

--- a/docs/deployed-contracts/hoodi.md
+++ b/docs/deployed-contracts/hoodi.md
@@ -12,9 +12,9 @@ Hoodi is the primary operational and actively maintained Lido protocol testnet. 
 
 **Deployment Information:**
 
-- ⚓ **Lido protocol version**: [**`v3.0.1`**](https://github.com/lidofinance/core/releases/tag/v3.0.1) (Lido V3 with stVaults — see [Technical Paper](/lido-v3-whitepaper))
-- 🌐 **Network**: Ethereum Hoodi (Chain ID: `560048`)
-- ✅ **Status**: Active and maintained
+- ⚓ Lido protocol version: [**`v3.0.2`**](https://github.com/lidofinance/core/releases/tag/v3.0.2)
+- 🌐 Network: Ethereum Hoodi (Chain ID: `560048`)
+- ✅ Status: Active and maintained
 
 **Key Resources on Lido V3:**
 

--- a/docs/deployed-contracts/index.md
+++ b/docs/deployed-contracts/index.md
@@ -16,7 +16,7 @@ This page lists production contract addresses on mainnets, including Ethereum an
 
 **Deployment Information:**
 
-- ⚓ Lido protocol version: [**`v3.0.1`**](https://github.com/lidofinance/core/releases/tag/v3.0.1)
+- ⚓ Lido protocol version: [**`v3.0.2`**](https://github.com/lidofinance/core/releases/tag/v3.0.2)
 - 🌐 Network: Ethereum Mainnet (Chain ID: `1`)
 - ✅ Status: Active and maintained
 

--- a/docs/integrations/aave/aip.md
+++ b/docs/integrations/aave/aip.md
@@ -13,7 +13,7 @@ We propose listing stETH to AAVE v2 market. This would allow users to borrow aga
 
 - Website: [lido.fi](https://lido.fi/)
 - [Document portal](https://docs.lido.fi/)
-- [Source code for the system(s) that interact with the proposed token](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.4.24/Lido.sol)
+- [Source code for the system(s) that interact with the proposed token](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.4.24/Lido.sol)
 - [Ethereum addresses contracts](/deployed-contracts)
 - [ChainLink Oracle](https://etherscan.io/address/0x86392dC19c0b719886221c78AB11eb8Cf5c52812)
 - [Audits](https://github.com/lidofinance/audits)

--- a/docs/integrations/api.md
+++ b/docs/integrations/api.md
@@ -28,7 +28,7 @@ https://eth-api-hoodi.testnet.fi/v1/protocol/steth/apr/sma
 
 ### Last Lido APR for stETH
 
-The latest staking APR value. For legacy deployments, APR values were collected by periodically fetching oracle report events. For Lido V2+ the value is calculated based on [rebase events](https://github.com/lidofinance/core/blob/v3.0.1/contracts/0.4.24/Lido.sol#L163-L171) using the following algorithm:
+The latest staking APR value. For legacy deployments, APR values were collected by periodically fetching oracle report events. For Lido V2+ the value is calculated based on [rebase events](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.4.24/Lido.sol#L163-L171) using the following algorithm:
 
 ```solidity
 // Emits when token rebased (total supply and/or total shares were changed)


### PR DESCRIPTION
Update references from v3.0.1 to v3.0.2 and align Hoodi Deployment Information style with Mainnet.