### PR TITLE
chore: add fetch-msig-quorums script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "format": "prettier --write docs/",
     "fetch-audits": "node scripts/fetch-audits.js",
     "fetch-external": "node scripts/fetch-external.js",
-    "fetch-lips": "node scripts/fetch-lips.js"
+    "fetch-lips": "node scripts/fetch-lips.js",
+    "check-msig-quorums": "node scripts/update-msig-quorums.js",
+    "update-msig-quorums": "node scripts/update-msig-quorums.js --write"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "fetch-audits": "node scripts/fetch-audits.js",
     "fetch-external": "node scripts/fetch-external.js",
     "fetch-lips": "node scripts/fetch-lips.js",
-    "check-msig-quorums": "node scripts/update-msig-quorums.js",
-    "update-msig-quorums": "node scripts/update-msig-quorums.js --write"
+    "fetch-msig-quorums": "node scripts/fetch-msig-quorums.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/fetch-msig-quorums.js
+++ b/scripts/fetch-msig-quorums.js
@@ -144,7 +144,9 @@ async function rpcCall(rpcUrl, to, data) {
 }
 
 function decodeUint(hex) {
-  if (!hex || hex.length < 2) throw new Error('empty rpc result');
+  // Some RPCs (notably zkSync) return `0x` for calls to nonexistent contracts
+  // instead of erroring; guard explicitly so we never write `NaN/N` into docs.
+  if (!hex || hex.length < 2 + 64) throw new Error(`empty rpc result: ${hex}`);
   return parseInt(hex.slice(2), 16);
 }
 
@@ -227,9 +229,13 @@ function* scanInline(lines) {
     const m = line.match(INLINE_QUORUM_RE);
     if (m && pending) {
       const lineNo = i;
+      const safe = pending;
+      // Consume the pairing — a later orphan `**Quorum:**` must require its own
+      // Safe link rather than re-pairing with this one.
+      pending = null;
       yield {
         lineNo,
-        ...pending,
+        ...safe,
         current: m[1].replace(/\s+/g, ''),
         // Tie the replacement to the `**Quorum:**` label so an unrelated `M/N`
         // elsewhere on the line cannot be clobbered.

--- a/scripts/fetch-msig-quorums.js
+++ b/scripts/fetch-msig-quorums.js
@@ -19,17 +19,29 @@ const DOC_DIRS = ['docs', 'earn', 'run-on-lido'];
 // Safe URL chain prefix → ordered list of public JSON-RPC endpoints. Each is
 // tried in turn on transient failures (5xx/4xx/network).
 const CHAIN_RPCS = {
-  eth:    ['https://eth.drpc.org', 'https://ethereum-rpc.publicnode.com', 'https://eth.llamarpc.com'],
-  base:   ['https://base.drpc.org', 'https://base-rpc.publicnode.com', 'https://base.llamarpc.com'],
-  arb1:   ['https://arbitrum.drpc.org', 'https://arbitrum-one-rpc.publicnode.com', 'https://arb1.arbitrum.io/rpc'],
-  oeth:   ['https://optimism.drpc.org', 'https://optimism-rpc.publicnode.com', 'https://mainnet.optimism.io'],
-  matic:  ['https://polygon.drpc.org', 'https://polygon-bor-rpc.publicnode.com', 'https://polygon-rpc.com'],
-  bnb:    ['https://bsc.drpc.org', 'https://bsc-rpc.publicnode.com', 'https://binance.llamarpc.com'],
-  zksync: ['https://zksync.drpc.org', 'https://mainnet.era.zksync.io'],
-  gno:    ['https://gnosis.drpc.org', 'https://gnosis-rpc.publicnode.com', 'https://rpc.gnosischain.com'],
-  avax:   ['https://avalanche.drpc.org', 'https://avalanche-c-chain-rpc.publicnode.com'],
-  celo:   ['https://celo.drpc.org', 'https://forno.celo.org'],
-  sep:    ['https://sepolia.drpc.org', 'https://ethereum-sepolia-rpc.publicnode.com'],
+  eth:      ['https://eth.drpc.org', 'https://ethereum-rpc.publicnode.com', 'https://eth.llamarpc.com'],
+  base:     ['https://base.drpc.org', 'https://base-rpc.publicnode.com', 'https://base.llamarpc.com'],
+  arb1:     ['https://arbitrum.drpc.org', 'https://arbitrum-one-rpc.publicnode.com', 'https://arb1.arbitrum.io/rpc'],
+  oeth:     ['https://optimism.drpc.org', 'https://optimism-rpc.publicnode.com', 'https://mainnet.optimism.io'],
+  matic:    ['https://polygon.drpc.org', 'https://polygon-bor-rpc.publicnode.com', 'https://polygon-rpc.com'],
+  bnb:      ['https://bsc.drpc.org', 'https://bsc-rpc.publicnode.com', 'https://binance.llamarpc.com'],
+  zksync:   ['https://zksync.drpc.org', 'https://mainnet.era.zksync.io'],
+  gno:      ['https://gnosis.drpc.org', 'https://gnosis-rpc.publicnode.com', 'https://rpc.gnosischain.com'],
+  avax:     ['https://avalanche.drpc.org', 'https://avalanche-c-chain-rpc.publicnode.com'],
+  celo:     ['https://celo.drpc.org', 'https://forno.celo.org'],
+  scr:      ['https://scroll.drpc.org', 'https://rpc.scroll.io'],
+  linea:    ['https://linea.drpc.org', 'https://rpc.linea.build'],
+  mnt:      ['https://mantle.drpc.org', 'https://rpc.mantle.xyz'],
+  mantle:   ['https://mantle.drpc.org', 'https://rpc.mantle.xyz'],
+  unichain: ['https://unichain.drpc.org', 'https://mainnet.unichain.org'],
+  ink:      ['https://ink.drpc.org', 'https://rpc-gel.inkonchain.com'],
+  lisk:     ['https://lisk.drpc.org', 'https://rpc.api.lisk.com'],
+  mode:     ['https://mode.drpc.org', 'https://mainnet.mode.network'],
+  soneium:  ['https://soneium.drpc.org', 'https://rpc.soneium.org'],
+  plasma:   ['https://plasma.drpc.org', 'https://rpc.plasma.to'],
+  sep:      ['https://sepolia.drpc.org', 'https://ethereum-sepolia-rpc.publicnode.com'],
+  holesky:  ['https://holesky.drpc.org', 'https://ethereum-holesky-rpc.publicnode.com'],
+  hoe:      ['https://hoodi.drpc.org', 'https://ethereum-hoodi-rpc.publicnode.com'],
 };
 
 const CONCURRENCY = 4;
@@ -73,7 +85,16 @@ const quorumCache = new Map();
 
 function fetchQuorum(chain, address) {
   const key = `${chain}:${address.toLowerCase()}`;
-  if (!quorumCache.has(key)) quorumCache.set(key, limit(() => resolveQuorum(chain, address)));
+  if (!quorumCache.has(key)) {
+    // Evict on rejection so a later reference to the same Safe within this
+    // run gets a fresh attempt against the fallback RPCs instead of inheriting
+    // a cached failure.
+    const promise = limit(() => resolveQuorum(chain, address)).catch((err) => {
+      if (quorumCache.get(key) === promise) quorumCache.delete(key);
+      throw err;
+    });
+    quorumCache.set(key, promise);
+  }
   return quorumCache.get(key);
 }
 

--- a/scripts/fetch-msig-quorums.js
+++ b/scripts/fetch-msig-quorums.js
@@ -2,11 +2,10 @@
 // Walks markdown files, finds every Safe multisig with a recorded `Quorum`
 // (either as a `Quorum` table column or an inline `**Quorum:** M/N` line next
 // to a Safe address), reads the multisig's threshold and owner count directly
-// from the contract via JSON-RPC, and compares it with the doc value.
-// Reports drift; writes the on-chain value back with `--write`.
+// from the contract via JSON-RPC, and rewrites cells where the doc value
+// drifted from the on-chain value.
 //
-//   node scripts/update-msig-quorums.js          # check, exit 1 on drift
-//   node scripts/update-msig-quorums.js --write  # apply changes
+//   node scripts/fetch-msig-quorums.js
 
 const fs = require('fs');
 const path = require('path');
@@ -39,8 +38,6 @@ const TABLE_SEP_CELL_RE = /^:?-{3,}:?$/;
 const QUORUM_HEADER_RE = /^quorum$/i;
 const INLINE_QUORUM_RE = /^\s*\*\*Quorum(?:\*\*:|:\*\*)\s*(\d+\s*\/\s*\d+)\s*$/;
 const HEADING_RE = /^#{1,6}\s/;
-
-const WRITE = process.argv.includes('--write');
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -292,19 +289,14 @@ async function main() {
   const results = await Promise.all(files.map((f) => processFile(f, onFileDone)));
 
   for (const { rel, content, original } of results) {
-    if (WRITE && content !== original) fs.writeFileSync(path.join(ROOT, rel), content);
+    if (content !== original) fs.writeFileSync(path.join(ROOT, rel), content);
   }
 
   const total = totals.ok + totals.drift + totals.error;
   console.log(`\n${total} checked: ${totals.ok} ok, ${totals.drift} drift, ${totals.error} error`);
-
-  if (totals.drift === 0) return 0;
-  if (WRITE) { console.log('Updated files written.'); return 0; }
-  console.log('Run with --write to apply changes.');
-  return 1;
 }
 
-main().then((code) => process.exit(code)).catch((err) => {
+main().catch((err) => {
   console.error(err);
-  process.exit(2);
+  process.exit(1);
 });

--- a/scripts/fetch-msig-quorums.js
+++ b/scripts/fetch-msig-quorums.js
@@ -45,10 +45,16 @@ const CHAIN_RPCS = {
 };
 
 const CONCURRENCY = 4;
-const SAFE_LINK_RE = /app\.safe\.global\/[^)]*[?&]safe=([a-z0-9]+):(0x[0-9a-fA-F]{40})/;
+const FETCH_TIMEOUT_MS = 15_000;
+// Match any URL/text containing a Safe `safe=<chain>:<address>` query param,
+// independent of the host/path (e.g. app.safe.global, safe.scroll.xyz,
+// multisig.mantle.xyz, …). Unsupported chain prefixes will surface as
+// `unsupported chain: <chain>` errors so coverage stays visible.
+const SAFE_LINK_RE = /[?&]safe=([a-z0-9]+):(0x[0-9a-fA-F]{40})/i;
 const TABLE_SEP_CELL_RE = /^:?-{3,}:?$/;
 const QUORUM_HEADER_RE = /^quorum$/i;
 const INLINE_QUORUM_RE = /^\s*\*\*Quorum(?:\*\*:|:\*\*)\s*(\d+\s*\/\s*\d+)\s*$/;
+const INLINE_QUORUM_REPLACE_RE = /(\*\*Quorum(?:\*\*:|:\*\*)\s*)\d+\s*\/\s*\d+/;
 const HEADING_RE = /^#{1,6}\s/;
 
 // ---------------------------------------------------------------------------
@@ -105,6 +111,9 @@ async function resolveQuorum(chain, address) {
     rpcCallWithFallback(rpcs, address, SELECTOR_GET_THRESHOLD).then(decodeUint),
     rpcCallWithFallback(rpcs, address, SELECTOR_GET_OWNERS).then(decodeArrayLength),
   ]);
+  if (!(threshold > 0 && threshold <= owners)) {
+    throw new Error(`invalid quorum: ${threshold}/${owners}`);
+  }
   return `${threshold}/${owners}`;
 }
 
@@ -122,10 +131,15 @@ async function rpcCallWithFallback(rpcs, to, data) {
 
 async function rpcCall(rpcUrl, to, data) {
   const body = JSON.stringify({ jsonrpc: '2.0', method: 'eth_call', params: [{ to, data }, 'latest'], id: 1 });
-  const res = await fetch(rpcUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body });
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!res.ok) throw new Error(`rpc HTTP ${res.status}`);
   const json = await res.json();
-  if (json.error) throw new Error(json.error.message);
+  if (json.error) throw new Error(json.error.message ?? JSON.stringify(json.error));
   return json.result;
 }
 
@@ -136,7 +150,10 @@ function decodeUint(hex) {
 
 function decodeArrayLength(hex) {
   // ABI-encoded address[]: offset(32) + length(32) + entries...
+  // For a single-arg dynamic return, the offset word is always 0x20.
   if (!hex || hex.length < 2 + 128) throw new Error('not an address[] response');
+  const offset = parseInt(hex.slice(2, 2 + 64), 16);
+  if (offset !== 0x20) throw new Error(`unexpected address[] offset: 0x${offset.toString(16)}`);
   return parseInt(hex.slice(2 + 64, 2 + 128), 16);
 }
 
@@ -210,12 +227,15 @@ function* scanInline(lines) {
     const m = line.match(INLINE_QUORUM_RE);
     if (m && pending) {
       const lineNo = i;
-      const matched = m[1];
       yield {
         lineNo,
         ...pending,
-        current: matched.replace(/\s+/g, ''),
-        write: (value) => { lines[lineNo] = lines[lineNo].replace(matched, value); },
+        current: m[1].replace(/\s+/g, ''),
+        // Tie the replacement to the `**Quorum:**` label so an unrelated `M/N`
+        // elsewhere on the line cannot be clobbered.
+        write: (value) => {
+          lines[lineNo] = lines[lineNo].replace(INLINE_QUORUM_REPLACE_RE, `$1${value}`);
+        },
       };
     }
   }
@@ -292,10 +312,10 @@ function formatCheck(c, refWidth) {
 
 async function main() {
   const totals = { ok: 0, drift: 0, error: 0 };
-  // Reserve enough width for the longest possible `chain:0x…` reference so
-  // columns align even when a short matic vs longer zksync prefix mix on a
-  // single page.
-  const REF_WIDTH = 'zksync:0x0000000000000000000000000000000000000000'.length;
+  // Reserve enough width for the longest configured `chain:0x…` reference so
+  // columns align even when short and long prefixes mix on a single page.
+  const longestChain = Object.keys(CHAIN_RPCS).reduce((a, b) => (b.length > a.length ? b : a), '');
+  const REF_WIDTH = `${longestChain}:0x${'0'.repeat(40)}`.length;
 
   const onFileDone = ({ rel, checks }) => {
     if (checks.length === 0) return;

--- a/scripts/update-msig-quorums.js
+++ b/scripts/update-msig-quorums.js
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+// Walks markdown files, finds every Safe multisig with a recorded `Quorum`
+// (either as a `Quorum` table column or an inline `**Quorum:** M/N` line next
+// to a Safe address), reads the multisig's threshold and owner count directly
+// from the contract via JSON-RPC, and compares it with the doc value.
+// Reports drift; writes the on-chain value back with `--write`.
+//
+//   node scripts/update-msig-quorums.js          # check, exit 1 on drift
+//   node scripts/update-msig-quorums.js --write  # apply changes
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+const ROOT = path.resolve(__dirname, '..');
+const DOC_DIRS = ['docs', 'earn', 'run-on-lido'];
+
+// Safe URL chain prefix → ordered list of public JSON-RPC endpoints. Each is
+// tried in turn on transient failures (5xx/4xx/network).
+const CHAIN_RPCS = {
+  eth:    ['https://eth.drpc.org', 'https://ethereum-rpc.publicnode.com', 'https://eth.llamarpc.com'],
+  base:   ['https://base.drpc.org', 'https://base-rpc.publicnode.com', 'https://base.llamarpc.com'],
+  arb1:   ['https://arbitrum.drpc.org', 'https://arbitrum-one-rpc.publicnode.com', 'https://arb1.arbitrum.io/rpc'],
+  oeth:   ['https://optimism.drpc.org', 'https://optimism-rpc.publicnode.com', 'https://mainnet.optimism.io'],
+  matic:  ['https://polygon.drpc.org', 'https://polygon-bor-rpc.publicnode.com', 'https://polygon-rpc.com'],
+  bnb:    ['https://bsc.drpc.org', 'https://bsc-rpc.publicnode.com', 'https://binance.llamarpc.com'],
+  zksync: ['https://zksync.drpc.org', 'https://mainnet.era.zksync.io'],
+  gno:    ['https://gnosis.drpc.org', 'https://gnosis-rpc.publicnode.com', 'https://rpc.gnosischain.com'],
+  avax:   ['https://avalanche.drpc.org', 'https://avalanche-c-chain-rpc.publicnode.com'],
+  celo:   ['https://celo.drpc.org', 'https://forno.celo.org'],
+  sep:    ['https://sepolia.drpc.org', 'https://ethereum-sepolia-rpc.publicnode.com'],
+};
+
+const CONCURRENCY = 4;
+const SAFE_LINK_RE = /app\.safe\.global\/[^)]*[?&]safe=([a-z0-9]+):(0x[0-9a-fA-F]{40})/;
+const TABLE_SEP_CELL_RE = /^:?-{3,}:?$/;
+const QUORUM_HEADER_RE = /^quorum$/i;
+const INLINE_QUORUM_RE = /^\s*\*\*Quorum(?:\*\*:|:\*\*)\s*(\d+\s*\/\s*\d+)\s*$/;
+const HEADING_RE = /^#{1,6}\s/;
+
+const WRITE = process.argv.includes('--write');
+
+// ---------------------------------------------------------------------------
+// Concurrency limiter
+// ---------------------------------------------------------------------------
+function createLimiter(max) {
+  let active = 0;
+  const queue = [];
+  const next = () => {
+    if (active >= max || queue.length === 0) return;
+    active++;
+    const { fn, resolve, reject } = queue.shift();
+    Promise.resolve()
+      .then(fn)
+      .then(resolve, reject)
+      .finally(() => { active--; next(); });
+  };
+  return (fn) => new Promise((resolve, reject) => { queue.push({ fn, resolve, reject }); next(); });
+}
+
+const limit = createLimiter(CONCURRENCY);
+
+// ---------------------------------------------------------------------------
+// Multisig threshold/owners read via JSON-RPC `eth_call`
+//
+// Safe (Gnosis Safe) ABI:
+//   getThreshold()                 selector 0xe75235b8 → uint256
+//   getOwners()                    selector 0xa0e67e2b → address[]
+// ---------------------------------------------------------------------------
+const SELECTOR_GET_THRESHOLD = '0xe75235b8';
+const SELECTOR_GET_OWNERS = '0xa0e67e2b';
+
+const quorumCache = new Map();
+
+function fetchQuorum(chain, address) {
+  const key = `${chain}:${address.toLowerCase()}`;
+  if (!quorumCache.has(key)) quorumCache.set(key, limit(() => resolveQuorum(chain, address)));
+  return quorumCache.get(key);
+}
+
+async function resolveQuorum(chain, address) {
+  const rpcs = CHAIN_RPCS[chain];
+  if (!rpcs) throw new Error(`unsupported chain: ${chain}`);
+  const [threshold, owners] = await Promise.all([
+    rpcCallWithFallback(rpcs, address, SELECTOR_GET_THRESHOLD).then(decodeUint),
+    rpcCallWithFallback(rpcs, address, SELECTOR_GET_OWNERS).then(decodeArrayLength),
+  ]);
+  return `${threshold}/${owners}`;
+}
+
+async function rpcCallWithFallback(rpcs, to, data) {
+  let lastErr;
+  for (const url of rpcs) {
+    try {
+      return await rpcCall(url, to, data);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error('no rpcs configured');
+}
+
+async function rpcCall(rpcUrl, to, data) {
+  const body = JSON.stringify({ jsonrpc: '2.0', method: 'eth_call', params: [{ to, data }, 'latest'], id: 1 });
+  const res = await fetch(rpcUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body });
+  if (!res.ok) throw new Error(`rpc HTTP ${res.status}`);
+  const json = await res.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+
+function decodeUint(hex) {
+  if (!hex || hex.length < 2) throw new Error('empty rpc result');
+  return parseInt(hex.slice(2), 16);
+}
+
+function decodeArrayLength(hex) {
+  // ABI-encoded address[]: offset(32) + length(32) + entries...
+  if (!hex || hex.length < 2 + 128) throw new Error('not an address[] response');
+  return parseInt(hex.slice(2 + 64, 2 + 128), 16);
+}
+
+// ---------------------------------------------------------------------------
+// Markdown scanners — yield `{ lineNo, chain, address, current, write(value) }`
+// ---------------------------------------------------------------------------
+function splitTableRow(line) {
+  const t = line.trim();
+  if (!t.startsWith('|') || !t.endsWith('|')) return null;
+  return t.slice(1, -1).split('|').map((c) => c.trim());
+}
+
+function rebuildTableRow(line, cells) {
+  // Preserve the original line's pipe positions and whitespace padding.
+  const m = line.match(/^(\s*\|)(.*)(\|\s*)$/);
+  if (!m) return line;
+  const segments = m[2].split('|');
+  if (segments.length !== cells.length) return line;
+  const inner = segments
+    .map((seg, idx) => seg.replace(/^(\s*).*?(\s*)$/, `$1${cells[idx]}$2`))
+    .join('|');
+  return `${m[1]}${inner}${m[3]}`;
+}
+
+function findSafeLink(text) {
+  const m = text.match(SAFE_LINK_RE);
+  return m && { chain: m[1], address: m[2] };
+}
+
+function* scanTables(lines) {
+  for (let i = 0; i < lines.length - 1; i++) {
+    const head = splitTableRow(lines[i]);
+    const sep = splitTableRow(lines[i + 1]);
+    if (!head || !sep || !sep.every((c) => TABLE_SEP_CELL_RE.test(c))) continue;
+    const qIdx = head.findIndex((h) => QUORUM_HEADER_RE.test(h));
+    if (qIdx === -1) continue;
+
+    let j = i + 2;
+    while (j < lines.length) {
+      const row = splitTableRow(lines[j]);
+      if (!row || row.length !== head.length) break;
+      const link = row.map(findSafeLink).find(Boolean);
+      if (link) {
+        const lineNo = j;
+        yield {
+          lineNo,
+          ...link,
+          current: row[qIdx],
+          write: (value) => {
+            const next = [...row];
+            next[qIdx] = value;
+            lines[lineNo] = rebuildTableRow(lines[lineNo], next);
+          },
+        };
+      }
+      j++;
+    }
+    i = j - 1;
+  }
+}
+
+function* scanInline(lines) {
+  let pending = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (HEADING_RE.test(line)) { pending = null; continue; }
+
+    const link = findSafeLink(line);
+    if (link) pending = link;
+
+    const m = line.match(INLINE_QUORUM_RE);
+    if (m && pending) {
+      const lineNo = i;
+      const matched = m[1];
+      yield {
+        lineNo,
+        ...pending,
+        current: matched.replace(/\s+/g, ''),
+        write: (value) => { lines[lineNo] = lines[lineNo].replace(matched, value); },
+      };
+    }
+  }
+}
+
+function* scanQuorumSites(lines) {
+  yield* scanTables(lines);
+  yield* scanInline(lines);
+}
+
+// ---------------------------------------------------------------------------
+// Per-file processing
+// ---------------------------------------------------------------------------
+async function processFile(file, onFileDone) {
+  const original = fs.readFileSync(file, 'utf8');
+  const lines = original.split('\n');
+  const rel = path.relative(ROOT, file);
+
+  const checks = await Promise.all(
+    [...scanQuorumSites(lines)].map(async (site) => {
+      try {
+        const onchain = await fetchQuorum(site.chain, site.address);
+        if (site.current === onchain) return { ...site, status: 'ok', onchain };
+        site.write(onchain);
+        return { ...site, status: 'drift', onchain };
+      } catch (err) {
+        return { ...site, status: 'error', message: err.message };
+      }
+    }),
+  );
+
+  // Preserve source order — `Promise.all` already returns results in input
+  // order, but sites came from two scanners (table + inline) which may not be
+  // sorted by lineNo overall.
+  checks.sort((a, b) => a.lineNo - b.lineNo);
+
+  onFileDone({ rel, checks });
+  return { rel, checks, content: lines.join('\n'), original };
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+function* walkMarkdown(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkMarkdown(p);
+    else if (entry.name.endsWith('.md')) yield p;
+  }
+}
+
+function discoverDocFiles() {
+  return DOC_DIRS
+    .map((d) => path.join(ROOT, d))
+    .filter((p) => fs.existsSync(p))
+    .flatMap((p) => [...walkMarkdown(p)]);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const SYMBOL = { ok: '✓', drift: '✗', error: '!' };
+
+function formatCheck(c, refWidth) {
+  const line = `L${String(c.lineNo + 1).padStart(5)}`;
+  const ref = `${c.chain}:${c.address}`.padEnd(refWidth);
+  const tail =
+    c.status === 'drift' ? `${c.current} → ${c.onchain}` :
+    c.status === 'error' ? `${c.current ?? '?'}  (${c.message})` :
+    c.current;
+  return `  ${SYMBOL[c.status]} ${line}  ${ref}  ${tail}`;
+}
+
+async function main() {
+  const totals = { ok: 0, drift: 0, error: 0 };
+  // Reserve enough width for the longest possible `chain:0x…` reference so
+  // columns align even when a short matic vs longer zksync prefix mix on a
+  // single page.
+  const REF_WIDTH = 'zksync:0x0000000000000000000000000000000000000000'.length;
+
+  const onFileDone = ({ rel, checks }) => {
+    if (checks.length === 0) return;
+    console.log(`\n${rel}`);
+    for (const c of checks) {
+      totals[c.status]++;
+      console.log(formatCheck(c, REF_WIDTH));
+    }
+  };
+
+  const files = discoverDocFiles();
+  const results = await Promise.all(files.map((f) => processFile(f, onFileDone)));
+
+  for (const { rel, content, original } of results) {
+    if (WRITE && content !== original) fs.writeFileSync(path.join(ROOT, rel), content);
+  }
+
+  const total = totals.ok + totals.drift + totals.error;
+  console.log(`\n${total} checked: ${totals.ok} ok, ${totals.drift} drift, ${totals.error} error`);
+
+  if (totals.drift === 0) return 0;
+  if (WRITE) { console.log('Updated files written.'); return 0; }
+  console.log('Run with --write to apply changes.');
+  return 1;
+}
+
+main().then((code) => process.exit(code)).catch((err) => {
+  console.error(err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/fetch-msig-quorums.js`: walks `docs/`, `earn/`, `run-on-lido/` for quorum cells (`Quorum` table column or inline `**Quorum:** M/N` next to a Safe address) and reads `getThreshold()` / `getOwners()` from each Safe via JSON-RPC (drpc.org / publicnode / native L2 endpoints, with fallback).
- Always rewrites cells where the doc value drifted from the on-chain value.
- Adds `npm run fetch-msig-quorums`, alongside the other `fetch-*` scripts.

## Test plan
- [x] `npm run fetch-msig-quorums` reports `38 ok, 0 drift, 0 error` on a clean tree
- [x] Manually perturb a `Quorum` cell, rerun → script rewrites it back to the on-chain value