### PR TITLE
Feat/sr 3.0 hoodi addresses

### DIFF
--- a/docs/deployed-contracts/hoodi.md
+++ b/docs/deployed-contracts/hoodi.md
@@ -12,7 +12,7 @@ Hoodi is the primary operational and actively maintained Lido protocol testnet. 
 
 **Deployment Information:**
 
-- ⚓ Lido protocol version: [**`v3.0.2`**](https://github.com/lidofinance/core/releases/tag/v3.0.2)
+- ⚓ Lido protocol version: [**`v3.1.0-rc.1`**](https://github.com/lidofinance/core/releases/tag/v3.1.0-rc.1)
 - 🌐 Network: Ethereum Hoodi (Chain ID: `560048`)
 - ✅ Status: Active and maintained
 
@@ -25,21 +25,25 @@ Hoodi is the primary operational and actively maintained Lido protocol testnet. 
 ## 🏛️ Core Protocol {#core-protocol}
 
 - Lido Locator: [`0xe2EF9536DAAAEBFf5b1c130957AB3E80056b06D8`](https://hoodi.etherscan.io/address/0xe2EF9536DAAAEBFf5b1c130957AB3E80056b06D8) (proxy)
-- Lido Locator: [`0x751a4aa1a29bc0c0e587aa04c3eabf0797f9b1a4`](https://hoodi.etherscan.io/address/0x751a4aa1a29bc0c0e587aa04c3eabf0797f9b1a4) (impl)
+- Lido Locator: [`0x2C33BE7c09bfBC8e41E7648d611d857fD4831b68`](https://hoodi.etherscan.io/address/0x2C33BE7c09bfBC8e41E7648d611d857fD4831b68) (impl)
 - Lido and stETH token: [`0x3508A952176b3c15387C97BE809eaffB1982176a`](https://hoodi.etherscan.io/address/0x3508A952176b3c15387C97BE809eaffB1982176a) (proxy)
+- Lido and stETH token: [`0x6147270470A9Ee5b55c33EA71e32000E5d6D8E6B`](https://hoodi.etherscan.io/address/0x6147270470A9Ee5b55c33EA71e32000E5d6D8E6B) (impl)
 - wstETH token: [`0x7E99eE3C66636DE415D2d7C880938F2f40f94De4`](https://hoodi.etherscan.io/address/0x7E99eE3C66636DE415D2d7C880938F2f40f94De4)
 - wstETH referral staker: [`0xf886BcC68b240316103fE8A12453Ce7831c2e835`](https://hoodi.etherscan.io/address/0xf886BcC68b240316103fE8A12453Ce7831c2e835)
 - EIP-712 helper for stETH: [`0x2A1d51BF3aAA7A7D027C8f561e5f579876a17B0a`](https://hoodi.etherscan.io/address/0x2A1d51BF3aAA7A7D027C8f561e5f579876a17B0a)
 - Staking Router: [`0xCc820558B39ee15C7C45B59390B503b83fb499A8`](https://hoodi.etherscan.io/address/0xCc820558B39ee15C7C45B59390B503b83fb499A8) (proxy)
-- Staking Router: [`0xd5F04A81ac472B2cB32073CE9dDABa6FaF022827`](https://hoodi.etherscan.io/address/0xd5F04A81ac472B2cB32073CE9dDABa6FaF022827) (impl)
-- Deposit Security Module: [`0x2F0303F20E0795E6CCd17BD5efE791A586f28E03`](https://hoodi.etherscan.io/address/0x2F0303F20E0795E6CCd17BD5efE791A586f28E03)
+- Staking Router: [`0x44d0b2B95d2C2bDF73FE4f5cD7E3A930494E5B1f`](https://hoodi.etherscan.io/address/0x44d0b2B95d2C2bDF73FE4f5cD7E3A930494E5B1f) (impl)
+- Deposit Security Module: [`0x1a629bB7C0563650e46406Eb6764A2ba207a0eFE`](https://hoodi.etherscan.io/address/0x1a629bB7C0563650e46406Eb6764A2ba207a0eFE)
+- TopUp Gateway: [`0x10DBEb3367876826d00D21718D1d893e0fbD2956`](https://hoodi.etherscan.io/address/0x10DBEb3367876826d00D21718D1d893e0fbD2956) (proxy)
+- TopUp Gateway: [`0xFd1b63657dda65C4E6fDEF9d1f37064D078e9B49`](https://hoodi.etherscan.io/address/0xFd1b63657dda65C4E6fDEF9d1f37064D078e9B49) (impl)
 - Execution Layer Rewards Vault: [`0x9b108015fe433F173696Af3Aa0CF7CDb3E104258`](https://hoodi.etherscan.io/address/0x9b108015fe433F173696Af3Aa0CF7CDb3E104258)
 - Withdrawal Queue ERC721: [`0xfe56573178f1bcdf53F01A6E9977670dcBBD9186`](https://hoodi.etherscan.io/address/0xfe56573178f1bcdf53F01A6E9977670dcBBD9186) (proxy)
 - Withdrawal Vault: [`0x4473dCDDbf77679A643BdB654dbd86D67F8d32f2`](https://hoodi.etherscan.io/address/0x4473dCDDbf77679A643BdB654dbd86D67F8d32f2) (proxy)
-- Withdrawal Vault: [`0xfe7A58960Af333eAdeAeC39149F9d6A71dc3E668`](https://hoodi.etherscan.io/address/0xfe7A58960Af333eAdeAeC39149F9d6A71dc3E668) (impl)
+- Withdrawal Vault: [`0xB97e67CC20bd2970E30341c0ECc7497d8A5b7342`](https://hoodi.etherscan.io/address/0xB97e67CC20bd2970E30341c0ECc7497d8A5b7342) (impl)
 - Accounting: [`0x9b5b78D1C9A3238bF24662067e34c57c83E8c354`](https://hoodi.etherscan.io/address/0x9b5b78D1C9A3238bF24662067e34c57c83E8c354) (proxy)
+- Accounting: [`0xDB47544d5813f15116bf95c1cF2ff4dEdb2226fD`](https://hoodi.etherscan.io/address/0xDB47544d5813f15116bf95c1cF2ff4dEdb2226fD) (impl)
 - Burner: [`0xb2c99cd38a2636a6281a849C8de938B3eF4A7C3D`](https://hoodi.etherscan.io/address/0xb2c99cd38a2636a6281a849C8de938B3eF4A7C3D) (proxy)
-- Min First Allocation Strategy: [`0x6d1a9bBFF97f7565e9532FEB7b499982848E5e07`](https://hoodi.etherscan.io/address/0x6d1a9bBFF97f7565e9532FEB7b499982848E5e07) (external lib)
+- Min First Allocation Strategy: [`0x8E6FDB231D7CE30C2459319c0d4c4Eb4B681f9C9`](https://hoodi.etherscan.io/address/0x8E6FDB231D7CE30C2459319c0d4c4Eb4B681f9C9) (external lib)
 - MEV Boost Relay Allowed List: [`0x279d3A456212a1294DaEd0faEE98675a52E8A4Bf`](https://hoodi.etherscan.io/address/0x279d3A456212a1294DaEd0faEE98675a52E8A4Bf)
 - Triggerable Withdrawals Gateway: [`0x6679090D92b08a2a686eF8614feECD8cDFE209db`](https://hoodi.etherscan.io/address/0x6679090D92b08a2a686eF8614feECD8cDFE209db)
 - Validator Exit Delay Verifier: [`0xa5F5A9360275390fF9728262a29384399f38d2f0`](https://hoodi.etherscan.io/address/0xa5F5A9360275390fF9728262a29384399f38d2f0)
@@ -57,17 +61,25 @@ Hoodi is the primary operational and actively maintained Lido protocol testnet. 
 - Dashboard Implementation: [`0x38131D5548Be57A34937521fe427a23f49e1e2d4`](https://hoodi.etherscan.io/address/0x38131D5548Be57A34937521fe427a23f49e1e2d4)
 - Validator Consolidation Requests: [`0xbf95Cd394cC03cD03fEA62A435ac347314877f1d`](https://hoodi.etherscan.io/address/0xbf95Cd394cC03cD03fEA62A435ac347314877f1d)
 
+### 🔗 Consolidation Flow {#consolidation-flow}
+
+- Consolidation Migrator: [`0x747d357F5b6410B80Eb63406FaC5E2A91131B4f8`](https://hoodi.etherscan.io/address/0x747d357F5b6410B80Eb63406FaC5E2A91131B4f8) (proxy)
+- Consolidation Migrator: [`0x2A8585201BFD6830944f0bf008B774e7e32b380d`](https://hoodi.etherscan.io/address/0x2A8585201BFD6830944f0bf008B774e7e32b380d) (impl)
+- Consolidation Bus: [`0xe09fBcE63826468867eE66Eda491E444829E022A`](https://hoodi.etherscan.io/address/0xe09fBcE63826468867eE66Eda491E444829E022A) (proxy)
+- Consolidation Bus: [`0x27Ff16a465c1A00a727dd3Dbd479c5F3De275a1f`](https://hoodi.etherscan.io/address/0x27Ff16a465c1A00a727dd3Dbd479c5F3De275a1f) (impl)
+- Consolidation Gateway: [`0xC9991Bb865d025364BCbBd99f36e85889Fb68e69`](https://hoodi.etherscan.io/address/0xC9991Bb865d025364BCbBd99f36e85889Fb68e69)
+
 ## 🔮 Oracle Contracts {#oracle-contracts}
 
 - Accounting Oracle:
   - AccountingOracle: [`0xcb883B1bD0a41512b42D2dB267F2A2cd919FB216`](https://hoodi.etherscan.io/address/0xcb883B1bD0a41512b42D2dB267F2A2cd919FB216) (proxy)
-  - AccountingOracle: [`0x6D799F4C92e8eE9CC0E33367Dd47990ed49a21AC`](https://hoodi.etherscan.io/address/0x6D799F4C92e8eE9CC0E33367Dd47990ed49a21AC) (impl)
+  - AccountingOracle: [`0x41bF10F28A1312f2241f86A2537A04b08e343C0a`](https://hoodi.etherscan.io/address/0x41bF10F28A1312f2241f86A2537A04b08e343C0a) (impl)
   - HashConsensus: [`0x32EC59a78abaca3f91527aeB2008925D5AaC1eFC`](https://hoodi.etherscan.io/address/0x32EC59a78abaca3f91527aeB2008925D5AaC1eFC)
 - Validators Exit Bus Oracle (Validator Exit Bus):
   - ValidatorsExitBusOracle: [`0x8664d394C2B3278F26A1B44B967aEf99707eeAB2`](https://hoodi.etherscan.io/address/0x8664d394C2B3278F26A1B44B967aEf99707eeAB2) (proxy)
-  - ValidatorsExitBusOracle: [`0x7E6d9C9C44417bf2EaF69685981646e9752D623A`](https://hoodi.etherscan.io/address/0x7E6d9C9C44417bf2EaF69685981646e9752D623A) (impl)
+  - ValidatorsExitBusOracle: [`0x86aeA211B30174b3ee5d294ECeaDbD7f1C575eF3`](https://hoodi.etherscan.io/address/0x86aeA211B30174b3ee5d294ECeaDbD7f1C575eF3) (impl)
   - HashConsensus: [`0x30308CD8844fb2DB3ec4D056F1d475a802DCA07c`](https://hoodi.etherscan.io/address/0x30308CD8844fb2DB3ec4D056F1d475a802DCA07c)
-- OracleReportSanityChecker: [`0x53417BA942bC86492bAF46FAbA8769f246422388`](https://hoodi.etherscan.io/address/0x53417BA942bC86492bAF46FAbA8769f246422388)
+- OracleReportSanityChecker: [`0x049A972e9cBEfFFc1c2543dFD0Fa892C2E9Ed6C5`](https://hoodi.etherscan.io/address/0x049A972e9cBEfFFc1c2543dFD0Fa892C2E9Ed6C5)
 - OracleDaemonConfig: [`0x2a833402e3F46fFC1ecAb3598c599147a78731a9`](https://hoodi.etherscan.io/address/0x2a833402e3F46fFC1ecAb3598c599147a78731a9)
 - Lazy Oracle: [`0xf41491C79C30e8f4862d3F4A5b790171adB8e04A`](https://hoodi.etherscan.io/address/0xf41491C79C30e8f4862d3F4A5b790171adB8e04A) (proxy)
 - Lazy Oracle: [`0xC372aBC601C4eE5aA82CA2bcb54Da5a1Ef492E82`](https://hoodi.etherscan.io/address/0xC372aBC601C4eE5aA82CA2bcb54Da5a1Ef492E82) (impl)
@@ -128,6 +140,7 @@ Each pausable contract below is covered by the CircuitBreaker and has a designat
 | [Triggerable Withdrawals Gateway](https://hoodi.etherscan.io/address/0x6679090D92b08a2a686eF8614feECD8cDFE209db) | [`0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102`](https://hoodi.etherscan.io/address/0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102) |
 | [Vault Hub](https://hoodi.etherscan.io/address/0x4C9fFC325392090F789255b9948Ab1659b797964) | [`0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102`](https://hoodi.etherscan.io/address/0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102) |
 | [Predeposit Guarantee](https://hoodi.etherscan.io/address/0xa5F55f3402beA2B14AE15Dae1b6811457D43581d) | [`0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102`](https://hoodi.etherscan.io/address/0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102) |
+| [Consolidation Gateway](https://hoodi.etherscan.io/address/0xC9991Bb865d025364BCbBd99f36e85889Fb68e69) | [`0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102`](https://hoodi.etherscan.io/address/0x83BCE68B4e8b7071b2a664a26e6D3Bc17eEe3102) |
 | [CSM Module](https://hoodi.etherscan.io/address/0x79CEf36D84743222f37765204Bec41E92a93E59d) | [`0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53`](https://hoodi.etherscan.io/address/0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53) |
 | [CSM Accounting](https://hoodi.etherscan.io/address/0xA54b90BA34C5f326BC1485054080994e38FB4C60) | [`0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53`](https://hoodi.etherscan.io/address/0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53) |
 | [CSM FeeOracle](https://hoodi.etherscan.io/address/0xe7314f561B2e72f9543F1004e741bab6Fc51028B) | [`0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53`](https://hoodi.etherscan.io/address/0x4AF43Ee34a6fcD1fEcA1e1F832124C763561dA53) |


### PR DESCRIPTION
This pull request updates the `docs/deployed-contracts/hoodi.md` documentation to reflect the latest deployed contract addresses on the Hoodi testnet. It introduces a new section for the consolidation flow contracts and updates several existing core protocol and oracle contract addresses.

**Core Protocol Updates:**
- Updated implementation addresses for `Lido Locator`, `Staking Router`, `Deposit Security Module`, `Withdrawal Vault`, `Accounting`, and `Min First Allocation Strategy` to their latest deployments.
- Added new proxy and implementation addresses for the `TopUp Gateway`.

**New Consolidation Flow Contracts:**
- Added a new section documenting the `Consolidation Migrator` (proxy and impl), `Consolidation Bus` (proxy and impl), and `Consolidation Gateway` contracts.

**Oracle Contracts Updates:**
- Updated implementation addresses for `AccountingOracle`, `ValidatorsExitBusOracle`, and `OracleReportSanityChecker` to their latest versions.