### PR TITLE
feat: add llms.txt and per-page markdown endpoints for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ To build the documentation locally and push the built version to the `gh-pages` 
 GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy
 ```
 
+## AI-friendly outputs
+
+The build produces three artifacts for AI agents and assistants:
+
+- `/llms.txt` — a [llmstxt.org](https://llmstxt.org)-compliant index of every doc page across `docs/`, `run-on-lido/`, and `earn/` with short descriptions
+- `/llms-full.txt` — concatenated markdown of the entire documentation, ready to drop into an LLM context window
+- `/<page-path>.md` — every doc page is also available as a raw markdown URL (append `.md` to any docs URL, e.g. `https://docs.lido.fi/contracts/lido.md`)
+
+Generation lives in [`src/plugins`](src/plugins/README.md) — see that README for plugin details, config, and customization.
+
 ## Fetch and refresh external content
 
 Fetch external markdown files to build an up-to-date version.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,3 +1,9 @@
+const aiArtifactsCollections = [
+  { path: 'docs', routeBasePath: '/', label: 'Main Docs' },
+  { path: 'run-on-lido', routeBasePath: 'run-on-lido', label: 'Run on Lido' },
+  { path: 'earn', routeBasePath: 'earn', label: 'Earn' },
+]
+
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = async function createConfigAsync() {
   return {
@@ -64,7 +70,7 @@ module.exports = async function createConfigAsync() {
             href: 'https://github.com/lidofinance',
             label: 'GitHub',
             position: 'right',
-          }
+          },
         ],
       },
     },
@@ -96,21 +102,13 @@ module.exports = async function createConfigAsync() {
           siteTitle: 'Lido Documentation',
           siteDescription:
             'Documentation for the Lido liquid staking protocol on Ethereum and L2s. Covers protocol contracts, integrations, node operator guides, CSM, stVaults, and the Earn product.',
-          collections: [
-            { path: 'docs', routeBasePath: '/', label: 'Main Docs' },
-            { path: 'run-on-lido', routeBasePath: 'run-on-lido', label: 'Run on Lido' },
-            { path: 'earn', routeBasePath: 'earn', label: 'Earn' },
-          ],
+          collections: aiArtifactsCollections,
         },
       ],
       [
         require.resolve('./src/plugins/markdown-source'),
         {
-          collections: [
-            { path: 'docs', routeBasePath: '/' },
-            { path: 'run-on-lido', routeBasePath: 'run-on-lido' },
-            { path: 'earn', routeBasePath: 'earn' },
-          ],
+          collections: aiArtifactsCollections,
         },
       ],
       [
@@ -172,7 +170,7 @@ module.exports = async function createConfigAsync() {
             {
               to: '/earn',
               from: '/earn/introduction',
-            }
+            },
           ],
         },
       ],
@@ -199,5 +197,5 @@ module.exports = async function createConfigAsync() {
         },
       ],
     ],
-  };
-};
+  }
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,6 +91,29 @@ module.exports = async function createConfigAsync() {
         { indexBlog: false, docsRouteBasePath: '/', indexPages: true },
       ],
       [
+        require.resolve('./src/plugins/llms-txt'),
+        {
+          siteTitle: 'Lido Documentation',
+          siteDescription:
+            'Documentation for the Lido liquid staking protocol on Ethereum and L2s. Covers protocol contracts, integrations, node operator guides, CSM, stVaults, and the Earn product.',
+          collections: [
+            { path: 'docs', routeBasePath: '/', label: 'Main Docs' },
+            { path: 'run-on-lido', routeBasePath: 'run-on-lido', label: 'Run on Lido' },
+            { path: 'earn', routeBasePath: 'earn', label: 'Earn' },
+          ],
+        },
+      ],
+      [
+        require.resolve('./src/plugins/markdown-source'),
+        {
+          collections: [
+            { path: 'docs', routeBasePath: '/' },
+            { path: 'run-on-lido', routeBasePath: 'run-on-lido' },
+            { path: 'earn', routeBasePath: 'earn' },
+          ],
+        },
+      ],
+      [
         '@docusaurus/plugin-client-redirects',
         {
           redirects: [
@@ -108,10 +131,7 @@ module.exports = async function createConfigAsync() {
             },
             {
               to: '/run-on-lido/stvaults/tech-documentation/pdg',
-              from: [
-                '/guides/stvaults/pdg',
-                '/run-on-lido/stvaults/pdg',
-              ],
+              from: ['/guides/stvaults/pdg', '/run-on-lido/stvaults/pdg'],
             },
             {
               to: '/run-on-lido/stvaults/operational-and-management-guides/health-monitoring-guide',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.1.0",
         "clsx": "^2.1.0",
+        "gray-matter": "^4.0.3",
         "prism-react-renderer": "^2.4.0",
         "prop-types": "^15.8.1",
         "react": "^19.0.0",
@@ -171,6 +172,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.2.tgz",
       "integrity": "sha512-y1IOpG6OSmTpGg/CT0YBb/EAhR2nsC18QWp9Jy8HO9iGySpcwaTvs5kHa17daP3BMTwWyaX9/1tDTDQshZzXdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.2",
         "@algolia/requester-browser-xhr": "5.49.2",
@@ -309,6 +311,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2156,6 +2159,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2178,6 +2182,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2287,6 +2292,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2708,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3712,6 +3719,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -3980,6 +3988,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
       "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.9.2",
         "@docusaurus/module-type-aliases": "3.9.2",
@@ -4898,6 +4907,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5635,6 +5645,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6263,6 +6274,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6621,6 +6633,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6688,6 +6701,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6733,6 +6747,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.2.tgz",
       "integrity": "sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.2",
         "@algolia/client-abtesting": "5.49.2",
@@ -7224,6 +7239,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7532,6 +7548,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -8236,6 +8253,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8555,6 +8573,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8964,6 +8983,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10148,6 +10168,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14910,6 +14931,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15499,6 +15521,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16402,6 +16425,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -17237,6 +17261,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17246,6 +17271,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17301,6 +17327,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -17329,6 +17356,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -19181,7 +19209,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -19632,6 +19661,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19883,6 +19913,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.0",
+    "gray-matter": "^4.0.3",
     "prism-react-renderer": "^2.4.0",
     "prop-types": "^15.8.1",
     "react": "^19.0.0",

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -1,0 +1,265 @@
+# Plugins
+
+Custom Docusaurus plugins that produce AI-friendly artifacts at build time. Both plugins run in the `postBuild` hook, so they execute after Docusaurus finishes generating the HTML site and never block or alter the regular build.
+
+| Plugin | Output | Purpose |
+|---|---|---|
+| [`llms-txt`](./llms-txt) | `build/llms.txt`, `build/llms-full.txt` | Site-level discovery for AI agents (llmstxt.org spec) |
+| [`markdown-source`](./markdown-source) | `build/<page>.md` for every doc | Per-page raw markdown endpoints |
+| [`_shared`](./_shared) | — | Shared markdown utilities used by both plugins |
+
+Both plugins are registered in [`docusaurus.config.js`](../../docusaurus.config.js) and receive identical `collections` config — the list of doc directories with their `routeBasePath`.
+
+---
+
+## `llms-txt`
+
+Generates two files at the site root that follow the [llmstxt.org](https://llmstxt.org) specification.
+
+### Outputs
+
+**`/llms.txt`** — compact index (~65 KB on this site). Format:
+
+```markdown
+# Lido Documentation
+
+> Documentation for the Lido liquid staking protocol on Ethereum and L2s...
+
+## Main Docs
+
+- [Introduction](https://docs.lido.fi/): This documentation is intended to introduce...
+- [Accounting](https://docs.lido.fi/contracts/accounting): Handles oracle reports...
+- ...
+
+## Run on Lido
+- ...
+
+## Earn
+- ...
+```
+
+Designed to fit comfortably in a single LLM call. Each entry is `[title](absolute_url): short_description`. Title comes from frontmatter `title` or first `# H1` (with anchor suffixes like `{#mainnet}` and leading emoji stripped). Description comes from frontmatter `description`, falling back to the first meaningful paragraph (skips headings, lists, blockquotes, JSX blocks).
+
+**`/llms-full.txt`** — full corpus (~2.2 MB). Format:
+
+```markdown
+# Lido Documentation - Full Content
+
+> ...
+
+---
+## Section: Main Docs
+
+---
+<!-- source: https://docs.lido.fi/contracts/lido -->
+
+# Lido
+
+... full page markdown ...
+
+---
+<!-- source: https://docs.lido.fi/contracts/burner -->
+
+# Burner
+...
+```
+
+Each page is preceded by a `<!-- source: ... -->` comment so an LLM can cite back to the canonical URL.
+
+### Config
+
+```js
+[
+  require.resolve('./src/plugins/llms-txt'),
+  {
+    siteTitle: 'Lido Documentation',
+    siteDescription: 'Documentation for the Lido liquid staking protocol...',
+    collections: [
+      { path: 'docs', routeBasePath: '/', label: 'Main Docs' },
+      { path: 'run-on-lido', routeBasePath: 'run-on-lido', label: 'Run on Lido' },
+      { path: 'earn', routeBasePath: 'earn', label: 'Earn' },
+    ],
+    indexFilename: 'llms.txt',     // optional, default 'llms.txt'
+    fullFilename: 'llms-full.txt', // optional, default 'llms-full.txt'
+  },
+],
+```
+
+| Option | Required | Description |
+|---|---|---|
+| `siteTitle` | yes | Used as the H1 in both files |
+| `siteDescription` | no | Rendered as a blockquote summary under the H1 |
+| `collections` | yes | List of `{ path, routeBasePath, label }`. `path` is relative to the project root; `routeBasePath` matches the corresponding `@docusaurus/plugin-content-docs` setting; `label` is the H2 section heading in `llms.txt` |
+| `indexFilename` | no | Filename for the index file (default `llms.txt`) |
+| `fullFilename` | no | Filename for the full corpus (default `llms-full.txt`) |
+
+### Behavior
+
+- Pages with frontmatter `draft: true` or `unlisted: true` are excluded
+- Files starting with `_` and dotfiles are skipped (treated as partials/private)
+- MDX is sanitized (see [_shared](#shared)) — JSX components and attributes are stripped
+- Pages are sorted alphabetically by permalink within each section
+- Build log: `[llms-txt] generated llms.txt and llms-full.txt (266 docs across 3 collections)`
+
+---
+
+## `markdown-source`
+
+For each doc page, writes the raw markdown source to `build/<page-path>.md`. An AI agent (or anyone) can fetch only the page they need without loading the whole corpus.
+
+### Outputs
+
+Examples of the URL mapping:
+
+| Doc page URL | Raw markdown URL | File written |
+|---|---|---|
+| `https://docs.lido.fi/` | `https://docs.lido.fi/index.md` | `build/index.md` |
+| `https://docs.lido.fi/contracts/lido` | `https://docs.lido.fi/contracts/lido.md` | `build/contracts/lido.md` |
+| `https://docs.lido.fi/run-on-lido/intro` | `https://docs.lido.fi/run-on-lido/intro.md` | `build/run-on-lido/intro.md` |
+| `https://docs.lido.fi/earn` | `https://docs.lido.fi/earn.md` | `build/earn.md` |
+
+Each file starts with a canonical comment that points back to the HTML page:
+
+```markdown
+<!-- canonical: https://docs.lido.fi/contracts/lido -->
+
+# Lido
+
+- [Source code](https://github.com/lidofinance/core/blob/v3.0.2/contracts/0.4.24/Lido.sol)
+- [Deployed contract](https://etherscan.io/address/0xae7ab9...)
+
+Liquid staking pool and a related ERC-20 rebasing token (`stETH`)
+
+## What is Lido?
+...
+```
+
+If the body already starts with an H1 (or contains an H1 matching the page title in the first 20 lines), no duplicate title is inserted.
+
+### Config
+
+```js
+[
+  require.resolve('./src/plugins/markdown-source'),
+  {
+    collections: [
+      { path: 'docs', routeBasePath: '/' },
+      { path: 'run-on-lido', routeBasePath: 'run-on-lido' },
+      { path: 'earn', routeBasePath: 'earn' },
+    ],
+  },
+],
+```
+
+| Option | Required | Description |
+|---|---|---|
+| `collections` | yes | Same `{ path, routeBasePath }` shape as `llms-txt`. `label` is ignored here |
+
+### Behavior
+
+- One `.md` file per source `.md`/`.mdx` (266 on this site)
+- Permalink comes from frontmatter `slug` if set, otherwise from filesystem path (with `index.md` collapsing to the parent directory)
+- Pages with `draft: true` are skipped
+- MDX is sanitized (see [_shared](#shared))
+- Robots: `static/robots.txt` blocks crawlers from indexing these URLs via `Disallow: /*.md$` — only matches URLs ending in `.md`, so regular HTML pages (which have no extension in their URL) are unaffected
+- Build log: `[markdown-source] generated 266 raw .md files`
+
+### Content type
+
+On GitHub Pages, `.md` files are served with `Content-Type: text/markdown; charset=utf-8` by default. The local `docusaurus serve` command does not set this header — verify against production after the first deploy:
+
+```bash
+curl -I https://docs.lido.fi/contracts/lido.md
+```
+
+---
+
+## `_shared`
+
+Internal module with the parsing and sanitization logic used by both plugins. Not registered in `docusaurus.config.js`.
+
+### Exports (`_shared/markdown-utils.js`)
+
+| Function | What it does |
+|---|---|
+| `walkMarkdownFiles(rootDir)` | Recursively lists `.md`/`.mdx` files under a collection, skipping dotfiles, `_partials`, and directories |
+| `loadDoc(absPath, collectionPath, routeBasePath)` | Reads a file, parses frontmatter via `gray-matter`, returns `{ permalink, title, description, body, frontmatter, ... }` |
+| `buildPermalink(absPath, collectionPath, routeBasePath, frontmatter)` | Computes the URL path. Respects frontmatter `slug:`. Collapses `index.md` to its parent. Honors `routeBasePath` prefix |
+| `extractTitle(fm, body)` | Frontmatter `title` → first `# H1` → fallback to filename. Strips `{#anchor}` suffixes and emoji |
+| `extractDescription(fm, body)` | Frontmatter `description` → first meaningful paragraph (skips headings, lists, blockquotes, JSX, code). Truncates at 200 chars |
+| `sanitizeMdx(content)` | The MDX-to-plain-markdown stripper (details below) |
+| `escapeMarkdown(text)` | Inlines a string for use inside list-item descriptions (collapses newlines) |
+
+### MDX sanitization rules
+
+`sanitizeMdx` runs the body through a sequence of regex transforms:
+
+1. Remove `import ... from '...'` and `export ...` lines
+2. Replace known components:
+   - `<PdfViewer pdfUrl="..." />` → `[PDF](url)`
+   - `<Link to="..."> text </Link>` → `[text](url)`
+3. Strip JSX-only attributes: `className=`, `style={...}`, `onClick={...}`, and any `attribute={...}` expression
+4. Remove uppercase-name JSX components: self-closing `<Foo ... />` and paired `<Foo>...</Foo>` (keeps children)
+5. Convert HTML headings `<h1>...</h1>` ... `<h6>...</h6>` to markdown `#` ... `######`
+6. Strip layout containers `<div>`, `<span>`, `<section>`, `<article>`, `<aside>`, `<header>`, `<footer>` (keeps inner text)
+7. Convert `<br>` to newline
+8. Remove MDX comments `{/* ... */}`
+9. Collapse runs of 3+ newlines to 2
+
+Inline HTML that markdown understands natively (`<strong>`, `<em>`, `<sub>`, `<code>`, etc.) is left untouched.
+
+### Adding support for a new MDX component
+
+If you introduce a new custom component used in docs, add a dedicated replacement rule inside `sanitizeMdx`. Example for a hypothetical `<Tabs>` component:
+
+```js
+out = out.replace(/<Tabs\b[^>]*>([\s\S]*?)<\/Tabs>/g, '$1')
+```
+
+Without an explicit rule, the generic uppercase-tag stripper (rule 4) will still remove the tags but may produce messier output for complex cases.
+
+---
+
+## Development tips
+
+**Iterating on a plugin without a full rebuild:**
+
+```bash
+rm -rf build && npm run build
+```
+
+The plugins only emit files at the very end. Look for the `[llms-txt]` and `[markdown-source]` lines near the end of build output.
+
+**Inspecting output:**
+
+```bash
+head -50 build/llms.txt
+grep -c "^<!-- source:" build/llms-full.txt   # should equal number of docs
+find build -name "*.md" | wc -l               # should equal number of docs
+```
+
+**Testing locally:**
+
+```bash
+npm run serve
+curl -I http://localhost:3000/contracts/lido.md
+curl http://localhost:3000/llms.txt | head
+```
+
+**Resetting a stuck build cache:**
+
+```bash
+npm run clear && npm run build
+```
+
+---
+
+## Why custom plugins
+
+Existing community plugins (`docusaurus-plugin-llms`, `docusaurus-markdown-source-plugin`) were considered. They were rejected because:
+
+- Neither supports multiple doc collections in one config call — this site has three (`docs`, `run-on-lido`, `earn`) with different `routeBasePath` values
+- Both are young single-maintainer projects (bus factor = 1)
+- The logic needed here is ~300 lines total and gives us full control over MDX edge cases specific to this codebase (e.g. the V3 whitepaper's hero JSX block)
+
+The trade-off is owning the parsing code. Markdown structure on this site is stable enough that this is a one-time cost.

--- a/src/plugins/_shared/markdown-utils.js
+++ b/src/plugins/_shared/markdown-utils.js
@@ -1,0 +1,188 @@
+const fs = require('fs')
+const path = require('path')
+const matter = require('gray-matter')
+
+const MD_EXTENSIONS = ['.md', '.mdx']
+
+function walkMarkdownFiles(rootDir) {
+  const results = []
+  if (!fs.existsSync(rootDir)) return results
+
+  const stack = [rootDir]
+  while (stack.length) {
+    const dir = stack.pop()
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith('.')) continue
+      if (entry.name.startsWith('_')) continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+        continue
+      }
+      if (!MD_EXTENSIONS.includes(path.extname(entry.name))) continue
+      results.push(full)
+    }
+  }
+  return results.sort()
+}
+
+function loadDoc(absPath, collectionPath, routeBasePath) {
+  const raw = fs.readFileSync(absPath, 'utf8')
+  const parsed = matter(raw)
+  const fm = parsed.data || {}
+  const body = parsed.content || ''
+
+  const permalink = buildPermalink(absPath, collectionPath, routeBasePath, fm)
+  const title = extractTitle(fm, body) || path.basename(absPath, path.extname(absPath))
+  const description = extractDescription(fm, body)
+
+  return {
+    absPath,
+    relPath: path.relative(collectionPath, absPath),
+    permalink,
+    frontmatter: fm,
+    body,
+    title,
+    description,
+  }
+}
+
+function buildPermalink(absPath, collectionPath, routeBasePath, frontmatter) {
+  const base = normalizeBase(routeBasePath)
+
+  if (frontmatter && frontmatter.slug) {
+    const slug = frontmatter.slug.startsWith('/') ? frontmatter.slug : `/${frontmatter.slug}`
+    return joinUrl(base, slug)
+  }
+
+  const rel = path.relative(collectionPath, absPath)
+  const noExt = rel.replace(/\.(md|mdx)$/i, '')
+  const parts = noExt.split(path.sep).filter(Boolean)
+
+  if (parts.length && parts[parts.length - 1].toLowerCase() === 'index') {
+    parts.pop()
+  }
+
+  const route = parts.length ? `/${parts.join('/')}` : '/'
+  return joinUrl(base, route)
+}
+
+function normalizeBase(routeBasePath) {
+  if (!routeBasePath || routeBasePath === '/') return ''
+  return routeBasePath.startsWith('/') ? routeBasePath : `/${routeBasePath}`
+}
+
+function joinUrl(base, route) {
+  if (!base) return route
+  if (route === '/') return base
+  return `${base}${route}`
+}
+
+function extractTitle(fm, body) {
+  const raw =
+    fm && typeof fm.title === 'string' && fm.title.trim() ? fm.title.trim() : (body.match(/^#\s+(.+?)\s*$/m) || [])[1]
+  if (!raw) return null
+  return raw
+    .replace(/\{#[^}]+\}/g, '')
+    .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function extractDescription(fm, body) {
+  if (fm && typeof fm.description === 'string' && fm.description.trim()) {
+    return fm.description.trim()
+  }
+  const cleaned = stripCodeFences(body)
+  const paragraph = cleaned
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .find((p) => {
+      if (!p) return false
+      if (p.startsWith('#')) return false
+      if (p.startsWith(':::')) return false
+      if (p.startsWith('import')) return false
+      if (p.startsWith('export')) return false
+      if (p.startsWith('>')) return false
+      if (p.startsWith('<')) return false
+      if (/^[-*+]\s/.test(p)) return false
+      if (/^\d+\.\s/.test(p)) return false
+      if (/^---+$/.test(p)) return false
+      return true
+    })
+  if (!paragraph) return ''
+  const text = sanitizeMdx(paragraph).replace(/\s+/g, ' ').trim()
+  return text.length > 200 ? `${text.slice(0, 197)}...` : text
+}
+
+function stripCodeFences(body) {
+  return body.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]+`/g, '')
+}
+
+function sanitizeMdx(content) {
+  let out = content
+
+  out = out.replace(/^\s*import\s+[^\n]+from\s+['"][^'"]+['"];?\s*$/gm, '')
+  out = out.replace(/^\s*import\s+['"][^'"]+['"];?\s*$/gm, '')
+  out = out.replace(/^\s*export\s+[^\n]+$/gm, '')
+
+  out = out.replace(/<PdfViewer\s+[^/>]*pdfUrl=["']([^"']+)["'][^/>]*\/?>/g, (_, src) => {
+    return `[PDF](${src})`
+  })
+
+  out = out.replace(/<Link\s+[^>]*to=["']([^"']+)["'][^>]*>([\s\S]*?)<\/Link>/g, (_, href, text) => {
+    const clean = text.replace(/<[^>]+>/g, '').trim()
+    return `[${clean || href}](${href})`
+  })
+
+  out = stripJsxAttributes(out)
+
+  out = out.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*\/>/g, '')
+  out = out.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*>([\s\S]*?)<\/\1>/g, '$2')
+
+  out = out.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, text) => {
+    const hashes = '#'.repeat(Number(level))
+    return `\n\n${hashes} ${text.replace(/\s+/g, ' ').trim()}\n\n`
+  })
+
+  out = out.replace(/<br\s*\/?>/gi, '\n')
+  out = out.replace(/<(div|span|section|article|aside|header|footer)\b[^>]*>/gi, '')
+  out = out.replace(/<\/(div|span|section|article|aside|header|footer)>/gi, '')
+
+  out = out.replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+
+  out = out
+    .split('\n')
+    .map((line) => (line.trim() === '' ? '' : line))
+    .join('\n')
+  out = out.replace(/\n{3,}/g, '\n\n').trim()
+
+  return out
+}
+
+function stripJsxAttributes(content) {
+  return content.replace(/<([a-zA-Z][a-zA-Z0-9]*)([^>]*)>/g, (match, tag, attrs) => {
+    if (!attrs) return `<${tag}>`
+    let cleaned = attrs
+    cleaned = cleaned.replace(/\s+className=(?:"[^"]*"|'[^']*'|\{[^}]*\})/g, '')
+    cleaned = cleaned.replace(/\s+style=(?:"[^"]*"|'[^']*'|\{\{[^}]*\}\}|\{[^}]*\})/g, '')
+    cleaned = cleaned.replace(/\s+on[A-Z][a-zA-Z]*=\{[^}]*\}/g, '')
+    cleaned = cleaned.replace(/\s+[a-zA-Z][a-zA-Z0-9-]*=\{[^}]*\}/g, '')
+    return `<${tag}${cleaned}>`
+  })
+}
+
+function escapeMarkdown(text) {
+  if (!text) return ''
+  return text.replace(/\r/g, '').replace(/\n+/g, ' ').trim()
+}
+
+module.exports = {
+  walkMarkdownFiles,
+  loadDoc,
+  buildPermalink,
+  sanitizeMdx,
+  extractTitle,
+  extractDescription,
+  escapeMarkdown,
+}

--- a/src/plugins/llms-txt/index.js
+++ b/src/plugins/llms-txt/index.js
@@ -1,0 +1,99 @@
+const fs = require('fs')
+const path = require('path')
+const { walkMarkdownFiles, loadDoc, sanitizeMdx, escapeMarkdown } = require('../_shared/markdown-utils')
+
+module.exports = function llmsTxtPlugin(_context, options) {
+  const {
+    collections = [],
+    siteTitle = 'Documentation',
+    siteDescription = '',
+    indexFilename = 'llms.txt',
+    fullFilename = 'llms-full.txt',
+  } = options || {}
+
+  return {
+    name: 'lido-llms-txt',
+    async postBuild({ siteConfig, outDir, siteDir }) {
+      const siteUrl = (siteConfig.url || '').replace(/\/$/, '')
+
+      const sections = collections.map((collection) => {
+        const collectionPath = path.resolve(siteDir, collection.path)
+        const files = walkMarkdownFiles(collectionPath)
+        const docs = files
+          .map((file) => loadDoc(file, collectionPath, collection.routeBasePath))
+          .filter((doc) => !doc.frontmatter.draft && doc.frontmatter.unlisted !== true)
+          .sort((a, b) => a.permalink.localeCompare(b.permalink))
+        return { ...collection, docs }
+      })
+
+      const indexBody = renderIndex(sections, siteUrl, siteTitle, siteDescription)
+      const fullBody = renderFull(sections, siteUrl, siteTitle, siteDescription)
+
+      fs.writeFileSync(path.join(outDir, indexFilename), indexBody, 'utf8')
+      fs.writeFileSync(path.join(outDir, fullFilename), fullBody, 'utf8')
+
+      const total = sections.reduce((acc, s) => acc + s.docs.length, 0)
+      console.log(
+        `[llms-txt] generated ${indexFilename} and ${fullFilename} (${total} docs across ${sections.length} collections)`,
+      )
+    },
+  }
+}
+
+function renderIndex(sections, siteUrl, siteTitle, siteDescription) {
+  const lines = []
+  lines.push(`# ${siteTitle}`)
+  lines.push('')
+  if (siteDescription) {
+    for (const line of siteDescription.split('\n')) {
+      lines.push(`> ${line}`)
+    }
+    lines.push('')
+  }
+
+  for (const section of sections) {
+    if (!section.docs.length) continue
+    lines.push(`## ${section.label || section.routeBasePath}`)
+    lines.push('')
+    for (const doc of section.docs) {
+      const url = `${siteUrl}${doc.permalink}`
+      const desc = escapeMarkdown(doc.description)
+      lines.push(desc ? `- [${doc.title}](${url}): ${desc}` : `- [${doc.title}](${url})`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').trim() + '\n'
+}
+
+function renderFull(sections, siteUrl, siteTitle, siteDescription) {
+  const parts = [`# ${siteTitle} - Full Content`, '']
+  if (siteDescription) {
+    parts.push(`> ${siteDescription.replace(/\n/g, ' ')}`)
+    parts.push('')
+  }
+
+  for (const section of sections) {
+    if (!section.docs.length) continue
+    parts.push(`---`)
+    parts.push(`## Section: ${section.label || section.routeBasePath}`)
+    parts.push('')
+    for (const doc of section.docs) {
+      const url = `${siteUrl}${doc.permalink}`
+      const body = sanitizeMdx(doc.body)
+      parts.push(`---`)
+      parts.push(`<!-- source: ${url} -->`)
+      parts.push('')
+      const head = body.split('\n').slice(0, 20).join('\n')
+      const hasTitleAlready = /^#\s+/m.test(head) || (doc.title && head.includes(`# ${doc.title}`))
+      if (!hasTitleAlready) {
+        parts.push(`# ${doc.title}`)
+        parts.push('')
+      }
+      parts.push(body)
+      parts.push('')
+    }
+  }
+
+  return parts.join('\n').trim() + '\n'
+}

--- a/src/plugins/markdown-source/index.js
+++ b/src/plugins/markdown-source/index.js
@@ -1,0 +1,67 @@
+const fs = require('fs')
+const path = require('path')
+const { walkMarkdownFiles, loadDoc, sanitizeMdx } = require('../_shared/markdown-utils')
+
+module.exports = function markdownSourcePlugin(_context, options) {
+  const { collections = [] } = options || {}
+
+  return {
+    name: 'lido-markdown-source',
+    async postBuild({ siteConfig, outDir, siteDir }) {
+      const siteUrl = (siteConfig.url || '').replace(/\/$/, '')
+      let written = 0
+      const seen = new Map()
+
+      for (const collection of collections) {
+        const collectionPath = path.resolve(siteDir, collection.path)
+        const files = walkMarkdownFiles(collectionPath)
+
+        for (const file of files) {
+          const doc = loadDoc(file, collectionPath, collection.routeBasePath)
+          if (doc.frontmatter.draft) continue
+
+          const targetPath = resolveTargetPath(outDir, doc.permalink)
+          if (seen.has(targetPath)) {
+            console.warn(
+              `[markdown-source] permalink collision at ${doc.permalink}: ${seen.get(targetPath)} vs ${doc.relPath} (overwriting)`,
+            )
+          }
+          seen.set(targetPath, doc.relPath)
+
+          const body = sanitizeMdx(doc.body)
+          const canonical = `${siteUrl}${doc.permalink}`
+          const content = renderMarkdownSource(doc, canonical, body)
+
+          fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+          fs.writeFileSync(targetPath, content, 'utf8')
+          written += 1
+        }
+      }
+
+      console.log(`[markdown-source] generated ${written} raw .md files`)
+    },
+  }
+}
+
+function resolveTargetPath(outDir, permalink) {
+  const trimmed = permalink.replace(/^\/+/, '').replace(/\/+$/, '')
+  const relative = trimmed === '' ? 'index.md' : `${trimmed}.md`
+  return path.join(outDir, relative)
+}
+
+function renderMarkdownSource(doc, canonical, body) {
+  const parts = [`<!-- canonical: ${canonical} -->`, '']
+  if (!hasHeading(body, doc.title)) {
+    parts.push(`# ${doc.title}`)
+    parts.push('')
+  }
+  parts.push(body)
+  return parts.join('\n').trim() + '\n'
+}
+
+function hasHeading(body, title) {
+  const head = body.split('\n').slice(0, 20).join('\n')
+  if (/^#\s+/m.test(head)) return true
+  if (title && head.includes(`# ${title}`)) return true
+  return false
+}

--- a/src/plugins/markdown-source/index.js
+++ b/src/plugins/markdown-source/index.js
@@ -18,7 +18,7 @@ module.exports = function markdownSourcePlugin(_context, options) {
 
         for (const file of files) {
           const doc = loadDoc(file, collectionPath, collection.routeBasePath)
-          if (doc.frontmatter.draft) continue
+          if (doc.frontmatter.draft || doc.frontmatter.unlisted === true) continue
 
           const targetPath = resolveTargetPath(outDir, doc.permalink)
           if (seen.has(targetPath)) {

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Disallow: /*.md$

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /
+# Uses non-standard `*` wildcard and `$` end-anchor (supported by Googlebot/Bingbot).
+# Spec-strict crawlers may ignore this and crawl .md endpoints.
 Disallow: /*.md$


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Generate an llmstxt.org-compliant `/llms.txt` index and a concatenated `/llms-full.txt` corpus at build time
2. Expose every doc page as a raw markdown endpoint (append `.md` to any docs URL)
3. Add two custom Docusaurus plugins (`llms-txt`, `markdown-source`) with a shared markdown utilities module
4. Exclude the new `.md` endpoints from search engine indexing via `robots.txt`
5. Document the new artifacts and plugin setup in the root README and `src/plugins/README.md`


### 🔎 Attach a source of truth or evidence that allows reviewers to confirm the changes independently
1. 
