### PR TITLE
fix AI markdown artifacts

### DIFF
--- a/src/plugins/_shared/markdown-utils.js
+++ b/src/plugins/_shared/markdown-utils.js
@@ -111,12 +111,15 @@ function extractDescription(fm, body) {
       return true
     })
   if (!paragraph) return ''
-  const text = sanitizeMdx(paragraph).replace(/\s+/g, ' ').trim()
+  const text = sanitizeMdx(paragraph)
+    .replace(/`([^`\n]+)`/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
   return text.length > 200 ? `${text.slice(0, 197)}...` : text
 }
 
 function stripCodeFences(body) {
-  return body.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]+`/g, '')
+  return body.replace(/```[\s\S]*?```/g, '')
 }
 
 function sanitizeMdx(content) {
@@ -137,8 +140,7 @@ function sanitizeMdx(content) {
 
   out = stripJsxAttributes(out)
 
-  out = out.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*\/>/g, '')
-  out = out.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*>([\s\S]*?)<\/\1>/g, '$2')
+  out = stripUppercaseJsxComponents(out)
 
   out = out.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, text) => {
     const hashes = '#'.repeat(Number(level))
@@ -170,6 +172,19 @@ function stripJsxAttributes(content) {
     cleaned = cleaned.replace(/\s+[a-zA-Z][a-zA-Z0-9-]*=\{[^}]*\}/g, '')
     return `<${tag}${cleaned}>`
   })
+}
+
+function stripUppercaseJsxComponents(content) {
+  let previous
+  let out = content
+
+  do {
+    previous = out
+    out = out.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*\/>/g, '')
+    out = out.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*>([\s\S]*?)<\/\1>/g, '$2')
+  } while (out !== previous)
+
+  return out
 }
 
 function escapeMarkdown(text) {


### PR DESCRIPTION
This pull request refactors the Markdown utilities to improve how JSX components and inline code are handled when extracting and sanitizing descriptions. The main changes focus on more robust removal of uppercase JSX components and improved extraction of text from Markdown content.

**Markdown and JSX handling improvements:**

* Added a new `stripUppercaseJsxComponents` function to recursively remove self-closing and paired uppercase JSX components, and updated `sanitizeMdx` to use this function instead of inline regex replacements. [[1]](diffhunk://#diff-1af9d7459b64d5f585892e21f050d9bc89969c57d14ccdabd3247e7f18adb9e3L140-R143) [[2]](diffhunk://#diff-1af9d7459b64d5f585892e21f050d9bc89969c57d14ccdabd3247e7f18adb9e3R177-R189)
* Updated `extractDescription` to strip backticks from inline code (e.g., `` `code` `` becomes `code`) when extracting text for descriptions.
* Modified `stripCodeFences` to only remove fenced code blocks and no longer strip inline code, preserving more content for downstream processing.