### PR TITLE
add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,6 +86,7 @@ module.exports = async function createConfigAsync() {
       ],
     ],
     plugins: [
+      'docusaurus-plugin-copy-page-button',
       [
         require.resolve('@easyops-cn/docusaurus-search-local'),
         { indexBlog: false, docsRouteBasePath: '/', indexPages: true },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.0",
+    "docusaurus-plugin-copy-page-button": "^0.5.1",
     "prism-react-renderer": "^2.4.0",
     "prop-types": "^15.8.1",
     "react": "^19.0.0",


### PR DESCRIPTION
adds docusaurus-plugin-copy-page-button to dependencies and plugins array

what it does: a "Copy page" button in the docs sidebar that exports the current page as clean markdown. also has one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown.

lido-specific angle: the integration guides, contracts pages, and oracle/rewards spec docs all carry a lot of "you need to read 3 surrounding pages" context. when an integrator is on, say, the wstETH or stMATIC integration guide and wants to ask claude "how do I plumb this into my vault contract", the per-page markdown handoff is the right unit — not the whole site, not a manually-pasted snippet that drops the context.

auto-injects into the TOC sidebar. theme-aware. ~5kb client. no config required.

shipping on Ethereum execution-apis, Sui, Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, Cardano and Arbitrum docs. listed in the Docusaurus community plugins page.

repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button (~10k installs/mo)
demo: https://portdeveloper.github.io/copy-page-button-showcase/

happy to close/rebase if not a fit