### PR TITLE
fix: update 301 links with trailing slash in secops pages

### DIFF
--- a/docs/security/audits.md
+++ b/docs/security/audits.md
@@ -993,7 +993,7 @@ See the [full report](https://github.com/lidofinance/audits/blob/main/L2/Starkne
 
 ### 10-2024 Quantstamp wstETH on Zircuit Verification
 
-The deployed contracts are verified against the [wstETH on Optimism](https://github.com/lidofinance/lido-l2) and [Governance crosschain bridges](https://github.com/lidofinance/governance-crosschain-bridges) references together with the [proposed setup](https://docs.lido.fi/token-guides/wsteth-bridging-guide#the-proposed-configuration) initialization.
+The deployed contracts are verified against the [wstETH on Optimism](https://github.com/lidofinance/lido-l2) and [Governance crosschain bridges](https://github.com/lidofinance/governance-crosschain-bridges) references together with the [proposed setup](https://docs.lido.fi/token-guides/wsteth-bridging-guide/#the-proposed-configuration) initialization.
 
 See [full report](https://github.com/lidofinance/audits/blob/main/L2/Zircuit_2024-10-02-Quantstamp-wstETH-deployment-verification.pdf) for more details.
 

--- a/docs/security/safeharbor.md
+++ b/docs/security/safeharbor.md
@@ -23,7 +23,7 @@ Adoption of the agreement complements audits and the ongoing Immunefi Lido bug b
 
 On-chain Safe Harbor Agreement Contract can be found at **0xe19f54e8322214839a87408f084aa14ebefe9e87** ([etherscan](https://etherscan.io/address/0xe19f54e8322214839a87408f084aa14ebefe9e87), [blockscout](https://eth.blockscout.com/address/0xE19F54E8322214839A87408f084aA14eBEfe9E87)).
 
-**Bounty Terms,** predetermined rewards for successful Whitehats that recover protocol funds (for more information, review the [Safe Harbor](https://frameworks.securityalliance.org/safe-harbor/scope-terms)):
+**Bounty Terms,** predetermined rewards for successful Whitehats that recover protocol funds (for more information, review the [Safe Harbor](https://frameworks.securityalliance.org/safe-harbor/scope-terms/)):
 
 - **Percentage**: 10.0% of the recovered amount
 - **Bounty Cap (USD)**: $2,000,000 (*the maximum bounty amount for a single Whitehat)*


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Fix 301 trailing slash redirects in secops pages

### 🔎 Attach a source of truth or evidence that allows reviewers to confirm the changes independently
1. 
