### PR TITLE
docs: add Chainlink CCIP partnership disclaimer to cross-chain tokens guide

### DIFF
--- a/docs/token-guides/cross-chain-tokens-guide.md
+++ b/docs/token-guides/cross-chain-tokens-guide.md
@@ -1,7 +1,8 @@
 # Lido cross-chain tokens adoption guide
 
-:::warning Disclaimer
-This guide provides recommendations supplied by the [Network Expansion Committee (NEC)](https://snapshot.org/#/lido-snapshot.eth/proposal/0x7cdf1af7cfeb472ae202c45fb6d7e952bb34bfcbc82113549986b2bc2d5f54c5). Following these recommendations increases the likelihood of recognition by the Committee, but does not guarantee it. Moreover, the Lido DAO vote, with a quorum established, can override any NEC decision at any time, even if it has already been implemented and released. Therefore, NEC makes no warranties, express or implied, and disclaims all implied warranties, including any warranty of the likelihood of the recognition or rejection by the Lido DAO.
+:::warning Outdated due to the Chainlink partnership
+
+Lido DAO has [adopted Chainlink CCIP as the official default cross-chain infrastructure for wstETH](https://research.lido.fi/t/announcing-strategic-partnership-with-chainlink-on-adopting-ccip-as-the-official-default-cross-chain-infrastructure-for-wsteth/10871). The bridging architecture and recommendations described on this page reflect the pre-CCIP setup and will be updated as the integration is rolled out.
 :::
 
 ## TL;DR
@@ -207,6 +208,7 @@ To provide the capability to react fast and reduce losses in case of a security 
 The bridge endpoint contracts should have the ability to set the resume and pause roles holders on a case-by-case basis. For the pause role, there should be at least two holders possible to be able to assign the dedicated Emergency Multisig which is [ratified by the Lido DAO](https://snapshot.org/#/lido-snapshot.eth/proposal/0xfe2a6a6506a642b616118363bc29aa83dd9ef2ec80447bb607a8f52c0a96aed0) as the second role holder.
 
 To curb the multisig's power, it is proposed to use the "Gate Seals" mechanic. The mechanic limits the pause duration and restricts the capability to pause to a single use. To grant the capability repeatedly, the Lido DAO vote is required. The mechanic has been implemented, e.g., for withdrawals in the Lido protocol on Ethereum in two parts:
+
 - one-time disposable pauser contact [Gate Seals](https://github.com/lidofinance/gate-seals);
 - [PausableUntil](https://github.com/lidofinance/lido-dao/blob/master/contracts/0.8.9/utils/PausableUntil.sol) contract (inherited by [WithdrawalQueue](https://github.com/lidofinance/lido-dao/blob/master/contracts/0.8.9/WithdrawalQueue.sol)).
 
@@ -317,66 +319,69 @@ Notation used:
 - `Emergency Brakes L2 Multisig` - Emergency Multisig on L2 (the same participants but using the L2 Safe instance).
 
 **L1 Custom Bridge Endpoint**
+
 - Upgradeable
-	- Proxy admin is `Lido Agent`
+  - Proxy admin is `Lido Agent`
 - Admin is `Lido Agent`
 - Deposits pausable by
-	- `Lido Agent`
-	- `Emergency Brakes Multisig`
+  - `Lido Agent`
+  - `Emergency Brakes Multisig`
 - Deposits resumable by
-	- `Lido Agent`
+  - `Lido Agent`
 - Withdrawals pausable by
-	- `Lido Agent`
-	- `Emergency Brakes Multisig`
+  - `Lido Agent`
+  - `Emergency Brakes Multisig`
 - Withdrawals resumable by
-	- `Lido Agent`
+  - `Lido Agent`
 
 **L2 Governance Executor**
 
 - The only allow-listed L1 execution sender is `Lido Agent`
 
 **L2 Custom Bridge Endpoint**
+
 - Upgradeable
-	- Proxy admin is `L2 Governance Executor`
+  - Proxy admin is `L2 Governance Executor`
 - Admin is `L2 Governance Executor`
 - Deposits pausable by
-	- `L2 Governance Executor`
-	- `Emergency Brakes Multisig`
+  - `L2 Governance Executor`
+  - `Emergency Brakes Multisig`
 - Deposits resumable by
-	- `L2 Governance Executor`
+  - `L2 Governance Executor`
 - Withdrawals pausable by
-	- `L2 Governance Executor`
-	- `Emergency Brakes Multisig`
+  - `L2 Governance Executor`
+  - `Emergency Brakes Multisig`
 - Withdrawals resumable by
-	- `L2 Governance Executor`
+  - `L2 Governance Executor`
 
 **L2 Token Bridged**
+
 - Upgradeable
-	- Proxy admin is `L2 Governance Executor`
+  - Proxy admin is `L2 Governance Executor`
 - Mint is allowed only by `L2 Custom Bridge`
 - Optionally applicable (if `L2 Custom Bridge` doesn't support these)
   - Admin is `L2 Governance Executor`
   - Withdrawals pausable by
-      - `L2 Governance Executor`
-      - `Emergency Brakes Multisig`
+    - `L2 Governance Executor`
+    - `Emergency Brakes Multisig`
   - Withdrawals resumable by
-      - `L2 Governance Executor`
+    - `L2 Governance Executor`
   - Deposits pausable by
-      - `L2 Governance Executor`
-      - `Emergency Brakes Multisig`
+    - `L2 Governance Executor`
+    - `Emergency Brakes Multisig`
   - Deposits resumable by
-      - `L2 Governance Executor`
+    - `L2 Governance Executor`
 
 ### Mainnet proposed configuration
 
 - `wstETH` - the wstETH token on L1
-	- `0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0`
+  - `0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0`
 - `Lido Agent` - Lido DAO Aragon Agent
-	- `0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c`
+  - `0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c`
 - `Emergency Brakes L1 Multisig`
-	- `0x73b047fe6337183A454c5217241D780a932777bD`
+  - `0x73b047fe6337183A454c5217241D780a932777bD`
 - `Emergency Brakes L2 Multisig`
-	- ask the NEC for the address (the deployed Safe instance would be needed)
+  - ask the NEC for the address (the deployed Safe instance would be needed)
 
 ### Testnet Holesky proposed configuration
 
@@ -385,24 +390,24 @@ Please, deploy to Holešky if possible because it has better long-term exposure 
 :::
 
 - `wstETH` - the wstETH token on L1
-	- `0x8d09a4502Cc8Cf1547aD300E066060D043f6982D`
+  - `0x8d09a4502Cc8Cf1547aD300E066060D043f6982D`
 - `Lido Agent` - Lido DAO Aragon Agent
-	- `0xE92329EC7ddB11D25e25b3c21eeBf11f15eB325d`
+  - `0xE92329EC7ddB11D25e25b3c21eeBf11f15eB325d`
 - `Emergency Brakes L1 Multisig`
-	- `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
+  - `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
 - `Emergency Brakes L2 Multisig`
-	- `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
+  - `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
 
 ### Testnet Sepolia proposed configuration
 
 - `wstETH` - the wstETH token on L1
-	- `0xB82381A3fBD3FaFA77B3a7bE693342618240067b`
+  - `0xB82381A3fBD3FaFA77B3a7bE693342618240067b`
 - `Lido Agent` - Lido DAO Aragon Agent
-	- `0x32A0E5828B62AAb932362a4816ae03b860b65e83`
+  - `0x32A0E5828B62AAb932362a4816ae03b860b65e83`
 - `Emergency Brakes L1 Multisig`
-	- `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
+  - `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
 - `Emergency Brakes L2 Multisig`
-	- `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
+  - `0xa5F1d7D49F581136Cf6e58B32cBE9a2039C48bA1` (EOA)
 
 ### Other questions
 
@@ -450,8 +455,6 @@ graph TD;
   A-- No -->C
   B-- No -->D
 ```
-
-
 
 ## References
 

--- a/docs/token-guides/cross-chain-tokens-guide.md
+++ b/docs/token-guides/cross-chain-tokens-guide.md
@@ -209,7 +209,7 @@ The bridge endpoint contracts should have the ability to set the resume and paus
 
 To curb the multisig's power, it is proposed to use the "Gate Seals" mechanic. The mechanic limits the pause duration and restricts the capability to pause to a single use. To grant the capability repeatedly, the Lido DAO vote is required. The mechanic has been implemented, e.g., for withdrawals in the Lido protocol on Ethereum in two parts:
 
-- one-time disposable pauser contact [Gate Seals](https://github.com/lidofinance/gate-seals);
+- one-time disposable pauser contract [Gate Seals](https://github.com/lidofinance/gate-seals);
 - [PausableUntil](https://github.com/lidofinance/lido-dao/blob/master/contracts/0.8.9/utils/PausableUntil.sol) contract (inherited by [WithdrawalQueue](https://github.com/lidofinance/lido-dao/blob/master/contracts/0.8.9/WithdrawalQueue.sol)).
 
 ### R-8: The contracts state
@@ -325,12 +325,12 @@ Notation used:
 - Admin is `Lido Agent`
 - Deposits pausable by
   - `Lido Agent`
-  - `Emergency Brakes Multisig`
+  - `Emergency Brakes L1 Multisig`
 - Deposits resumable by
   - `Lido Agent`
 - Withdrawals pausable by
   - `Lido Agent`
-  - `Emergency Brakes Multisig`
+  - `Emergency Brakes L1 Multisig`
 - Withdrawals resumable by
   - `Lido Agent`
 
@@ -345,12 +345,12 @@ Notation used:
 - Admin is `L2 Governance Executor`
 - Deposits pausable by
   - `L2 Governance Executor`
-  - `Emergency Brakes Multisig`
+  - `Emergency Brakes L2 Multisig`
 - Deposits resumable by
   - `L2 Governance Executor`
 - Withdrawals pausable by
   - `L2 Governance Executor`
-  - `Emergency Brakes Multisig`
+  - `Emergency Brakes L2 Multisig`
 - Withdrawals resumable by
   - `L2 Governance Executor`
 
@@ -363,12 +363,12 @@ Notation used:
   - Admin is `L2 Governance Executor`
   - Withdrawals pausable by
     - `L2 Governance Executor`
-    - `Emergency Brakes Multisig`
+    - `Emergency Brakes L2 Multisig`
   - Withdrawals resumable by
     - `L2 Governance Executor`
   - Deposits pausable by
     - `L2 Governance Executor`
-    - `Emergency Brakes Multisig`
+    - `Emergency Brakes L2 Multisig`
   - Deposits resumable by
     - `L2 Governance Executor`
 

--- a/docs/token-guides/cross-chain-tokens-guide.md
+++ b/docs/token-guides/cross-chain-tokens-guide.md
@@ -2,7 +2,7 @@
 
 :::warning Outdated due to the Chainlink partnership
 
-Per the Lido DAO mandate, the Lido Ecosystem is working to establish [Chainlink CCIP as the official default cross-chain infrastructure for wstETH](https://research.lido.fi/t/announcing-strategic-partnership-with-chainlink-on-adopting-ccip-as-the-official-default-cross-chain-infrastructure-for-wsteth/10871). The bridging architecture and recommendations outlined here reflect the current pre-CCIP setup and will be revised as the integration is rolled out
+Per the [Lido DAO mandate](https://snapshot.box/#/s:lido-snapshot.eth/proposal/0xf842517c2ffba082efac87ec43365e86548adb38e24d1446d850c7d7b979c423), the Lido Ecosystem is working to establish [Chainlink CCIP as the official default cross-chain infrastructure for wstETH](https://research.lido.fi/t/announcing-strategic-partnership-with-chainlink-on-adopting-ccip-as-the-official-default-cross-chain-infrastructure-for-wsteth/10871). The bridging architecture and recommendations outlined here reflect the current pre-CCIP setup and will be revised as the integration is rolled out.
 :::
 
 ## TL;DR

--- a/docs/token-guides/cross-chain-tokens-guide.md
+++ b/docs/token-guides/cross-chain-tokens-guide.md
@@ -2,7 +2,7 @@
 
 :::warning Outdated due to the Chainlink partnership
 
-Lido DAO has [adopted Chainlink CCIP as the official default cross-chain infrastructure for wstETH](https://research.lido.fi/t/announcing-strategic-partnership-with-chainlink-on-adopting-ccip-as-the-official-default-cross-chain-infrastructure-for-wsteth/10871). The bridging architecture and recommendations described on this page reflect the pre-CCIP setup and will be updated as the integration is rolled out.
+Per the Lido DAO mandate, the Lido Ecosystem is working to establish [Chainlink CCIP as the official default cross-chain infrastructure for wstETH](https://research.lido.fi/t/announcing-strategic-partnership-with-chainlink-on-adopting-ccip-as-the-official-default-cross-chain-infrastructure-for-wsteth/10871). The bridging architecture and recommendations outlined here reflect the current pre-CCIP setup and will be revised as the integration is rolled out
 :::
 
 ## TL;DR


### PR DESCRIPTION
<img width="1008" height="598" alt="Screenshot 2026-05-25 at 19 47 28" src="https://github.com/user-attachments/assets/0fde9aae-f884-436f-8cff-cdcc7882a68a" />

--- 

## Summary


- Adds a top-of-page warning to `docs/token-guides/cross-chain-tokens-guide.md` noting that the bridging architecture and recommendations describe the pre-CCIP setup.
- Links to the forum announcement of the strategic partnership with Chainlink on adopting CCIP as the official default cross-chain infrastructure for wstETH.
- Removes the previous NEC disclaimer, whose role is superseded by the Chainlink partnership.

The diff also includes whitespace normalization (tabs → spaces, blank lines before lists) applied automatically by the project linter when the file was saved.

## Test plan

- [x] Verify the rendered admonition appears at the top of the cross-chain tokens guide page
- [x] Verify the link to the forum proposal resolves