### PR TITLE
docs: point llms.txt links to Markdown sources

### DIFF
--- a/docs/integrations/aave/aip.md
+++ b/docs/integrations/aave/aip.md
@@ -1,3 +1,7 @@
+---
+description: AAVE governance proposal to add stETH as collateral to the AAVE v2 market.
+---
+
 # AIP
 
 | title                | status   | author              | shortDescription                                         | discussion                                                                                               | created    |

--- a/earn/deployment-contracts.md
+++ b/earn/deployment-contracts.md
@@ -1,5 +1,6 @@
 ---
 toc_max_heading_level: 3
+description: Deployment addresses for Lido Earn vaults and their supporting contracts.
 ---
 
 # Deployments

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -27,8 +27,8 @@ Generates two files at the site root that follow the [llmstxt.org](https://llmst
 
 ## Main Docs
 
-- [Introduction](https://docs.lido.fi/): This documentation is intended to introduce...
-- [Accounting](https://docs.lido.fi/contracts/accounting): Handles oracle reports...
+- [Introduction](https://docs.lido.fi/index.md): This documentation is intended to introduce...
+- [Accounting](https://docs.lido.fi/contracts/accounting.md): Handles oracle reports...
 - ...
 
 ## Run on Lido
@@ -38,7 +38,7 @@ Generates two files at the site root that follow the [llmstxt.org](https://llmst
 - ...
 ```
 
-Designed to fit comfortably in a single LLM call. Each entry is `[title](absolute_url): short_description`. Title comes from frontmatter `title` or first `# H1` (with anchor suffixes like `{#mainnet}` and leading emoji stripped). Description comes from frontmatter `description`, falling back to the first meaningful paragraph (skips headings, lists, blockquotes, JSX blocks).
+Designed to fit comfortably in a single LLM call. Each entry is `[title](raw_markdown_url): short_description`. Title comes from frontmatter `title` or first `# H1` (with anchor suffixes like `{#mainnet}` and leading emoji stripped). Description comes from frontmatter `description`, falling back to the first meaningful paragraph (skips headings, lists, blockquotes, JSX blocks).
 
 **`/llms-full.txt`** — full corpus (~2.2 MB). Format:
 

--- a/src/plugins/llms-txt/index.js
+++ b/src/plugins/llms-txt/index.js
@@ -56,7 +56,8 @@ function renderIndex(sections, siteUrl, siteTitle, siteDescription) {
     lines.push(`## ${section.label || section.routeBasePath}`)
     lines.push('')
     for (const doc of section.docs) {
-      const url = `${siteUrl}${doc.permalink}`
+      const pathname = doc.permalink.replace(/\/+$/, '') || '/index'
+      const url = `${siteUrl}${pathname}.md`
       const desc = escapeMarkdown(doc.description)
       lines.push(desc ? `- [${doc.title}](${url}): ${desc}` : `- [${doc.title}](${url})`)
     }


### PR DESCRIPTION
## Rationale

The Markdown source plugin already generates a `.md` endpoint for every documentation page, but `llms.txt` linked to the regular HTML pages.

Pages beginning with tables also produced table contents as their fallback descriptions when no explicit frontmatter description was provided.

## Summary

- point `llms.txt` entries to the generated raw Markdown endpoints
- add explicit descriptions for table-first AAVE AIP and Earn deployment pages
- update the plugin documentation examples