### PR TITLE
feat: update oracle version to 8.0.4

### DIFF
--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -6,13 +6,13 @@ Overview of core infrastructure components used in the Lido protocol.
 
 Oracle daemon for Lido decentralized staking service.
 
-- **Version**: 8.0.3
-- **Docker image**: sha256:0f97715ddd74e289b5133c1394984902a0027cfd0a91c2a85e1d9e741388dd4d, [lidofinance/oracle@sha256-0f97715ddd74e289b5133c1394984902a0027cfd0a91c2a85e1d9e741388dd4d](https://hub.docker.com/layers/lidofinance/oracle/8.0.3/images/sha256-0f97715ddd74e289b5133c1394984902a0027cfd0a91c2a85e1d9e741388dd4d)
-- **Commit hash**: [lidofinance/lido-oracle@1d0b944](https://github.com/lidofinance/lido-oracle/commit/1d0b9440fda2dd6d421a1756fa5604269f972a6d)
-- **Last update date**: 15 July, 2026
-- [**Repository**](https://github.com/lidofinance/lido-oracle/tree/8.0.3)
+- **Version**: 8.0.4
+- **Docker image**: sha256:f9d27415442f1f501117794c42c8ce95dc14912aaf61c2aac252e8ce2df0f6e1, [lidofinance/oracle@sha256-f9d27415442f1f501117794c42c8ce95dc14912aaf61c2aac252e8ce2df0f6e1](https://hub.docker.com/layers/lidofinance/oracle/8.0.4/images/sha256-f9d27415442f1f501117794c42c8ce95dc14912aaf61c2aac252e8ce2df0f6e1)
+- **Commit hash**: [lidofinance/lido-oracle@399a1c9](https://github.com/lidofinance/lido-oracle/commit/399a1c9e3ac6cd8a91337d84762319abc67d4340)
+- **Last update date**: 26 July, 2026
+- [**Repository**](https://github.com/lidofinance/lido-oracle/tree/8.0.4)
 - [**Documentation**](/guides/oracle-operator-manual)
-- [**Audit Report for v8.0.3 (Composable Security)**](https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20V8_0_3%20Security%20Consultation%20Report.pdf)
+- [**Audit Report for v8.0.4 (MixBytes)**](https://github.com/lidofinance/audits/blob/main/Mixbytes%20Lido%20Oracle%20Security%20Audit%20Report%20V8.0.4.pdf)
 
 ## Validator Ejector
 

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -12,6 +12,7 @@ Oracle daemon for Lido decentralized staking service.
 - **Last update date**: 26 July, 2026
 - [**Repository**](https://github.com/lidofinance/lido-oracle/tree/8.0.4)
 - [**Documentation**](/guides/oracle-operator-manual)
+- [**Audit Report for v8.0.3 (Composable Security)**](https://github.com/lidofinance/audits/blob/main/Composable%20Security%20Lido%20Oracle%20V8_0_3%20Security%20Consultation%20Report.pdf)
 - [**Audit Report for v8.0.4 (MixBytes)**](https://github.com/lidofinance/audits/blob/main/Mixbytes%20Lido%20Oracle%20Security%20Audit%20Report%20V8.0.4.pdf)
 
 ## Validator Ejector


### PR DESCRIPTION
Updates the Oracle entry in `docs/guides/tooling.md` for today's 8.0.4 release.

- **Version**: `8.0.3` → `8.0.4`
- **Docker image**: digest `sha256:f9d27415442f1f501117794c42c8ce95dc14912aaf61c2aac252e8ce2df0f6e1` ([Docker Hub](https://hub.docker.com/layers/lidofinance/oracle/8.0.4/images/sha256-f9d27415442f1f501117794c42c8ce95dc14912aaf61c2aac252e8ce2df0f6e1))
- **Commit hash**: [`399a1c9`](https://github.com/lidofinance/lido-oracle/commit/399a1c9e3ac6cd8a91337d84762319abc67d4340), resolved from tag [`8.0.4`](https://github.com/lidofinance/lido-oracle/tree/8.0.4)
- **Last update date**: 26 July, 2026
- **Audit report**: v8.0.3 (Composable Security) → v8.0.4 (MixBytes)

## Dependency — merge order

The audit link points at `blob/main/Mixbytes Lido Oracle Security Audit Report V8.0.4.pdf`, which is added by lidofinance/audits#181. That PR is still open, so **the link 404s until it merges** — land audits#181 first, then this one.

Note the auditor changed for this release: 8.0.2 / 8.0.3 were Composable Security *consultation* reports, 8.0.4 is a MixBytes *audit* report, hence the relabelled bullet. Filename casing (`Mixbytes`) matches the file as added in audits#181, which differs from the `MixBytes` spelling used elsewhere in that repo — the URL is intentionally exact.

## Not changed

- `docs/guides/oracle-operator-manual.md` uses `lidofinance/oracle@<image-hash>` placeholders, not a pinned version.
- `docs/security/audits.md` has no V8-series oracle entries (8.0.2 / 8.0.3 reports were never listed there). Adding them is a separate decision.