### PR TITLE
ORC-781: feat: update depositor bot to 5.6.0

### DIFF
--- a/docs/guides/depositor-bot.md
+++ b/docs/guides/depositor-bot.md
@@ -32,12 +32,13 @@ noticeably more RAM and network bandwidth than the figures above — size the ho
 ### Nodes
 
 - Ethereum EL RPC service
-- Onchain databus transport RPC service (Gnosis at the moment)
-
-Required only when top-ups are enabled (`ENABLE_TOP_UP=true`):
-
 - Ethereum CL RPC service with the debug API available (`/eth/v2/debug/beacon/states`)
 - [Lido Keys API](/guides/tooling/#keys-api) instance
+- Onchain databus transport RPC service (Gnosis at the moment)
+
+The CL node and the Keys API are only *used* by the top-up path, but the depositor bot verifies that the EL, CL and
+Keys API endpoints are reachable and report the same chain id on start up. It therefore requires all of them even when
+`ENABLE_TOP_UP=false`, and exits on start up if they are missing or unreachable.
 
 ## How to use
 
@@ -73,8 +74,8 @@ Required variables are(mainnet):
 | DEPOSIT_MODULES_WHITELIST         | -                                          | Comma separated list of staking module's ids in which the depositor bot will make deposits and top-ups                    |
 | ---                               | ---	                                       | ---                                                                                                                      |
 | ENABLE_TOP_UP                     | false                                      | Enables top-ups of `0x02` modules. Keep disabled until Node Operators submit consolidation requests                       |
-| CL_API_URLS                       | -                                          | Comma separated list of CL endpoints. Required when `ENABLE_TOP_UP=true`                                                  |
-| KEYS_API_URL                      | -                                          | [Keys API](/guides/tooling/#keys-api) URL. Required when `ENABLE_TOP_UP=true`                                             |
+| CL_API_URLS                       | -                                          | Comma separated list of CL endpoints. Required even when `ENABLE_TOP_UP=false`                                             |
+| KEYS_API_URL                      | -                                          | [Keys API](/guides/tooling/#keys-api) URL. Required even when `ENABLE_TOP_UP=false`                                       |
 | MAX_VALIDATORS_PER_TOP_UP         | 32                                         | Maximum number of validators per top-up transaction (also capped onchain by the `TopUpGateway`)                           |
 | ---                               | ---	                                       | ---                                                                                                                      |
 | MESSAGE_TRANSPORTS                | -                                          | Transports used in bot. Set: onchain_transport                                                                           |

--- a/docs/guides/depositor-bot.md
+++ b/docs/guides/depositor-bot.md
@@ -10,6 +10,15 @@ deposit is executed using
 the [depositBufferedEther](/contracts/deposit-security-module/#depositbufferedether) function within
 the [DepositSecurityModule](/contracts/deposit-security-module) smart contract.
 
+Since v5.6.0 the bot also performs **top-ups**: adding ETH to already-active validators of `0x02` (compounding)
+staking modules through the `TopUpGateway` contract. Top-ups do not require a guardian quorum — only the bot itself
+can submit them — and they keep working while deposits are paused in the DSM. Top-ups are disabled by default
+(`ENABLE_TOP_UP=false`) and must stay disabled until Node Operators have submitted consolidation requests.
+
+The full per-iteration algorithm (module prioritisation, seed deposits vs. top-ups, validator selection) is described
+in [depositor-algorithm.md](https://github.com/lidofinance/depositor-bot/blob/main/docs/depositor-algorithm.md) in the
+bot repository.
+
 ## Requirements
 
 ### Hardware
@@ -17,10 +26,18 @@ the [DepositSecurityModule](/contracts/deposit-security-module) smart contract.
 - 1-core CPU
 - 2GB RAM
 
+With top-ups enabled the bot fetches and decodes the full beacon state (SSZ) to build validator proofs, which needs
+noticeably more RAM and network bandwidth than the figures above — size the host against the current validator set.
+
 ### Nodes
 
 - Ethereum EL RPC service
 - Onchain databus transport RPC service (Gnosis at the moment)
+
+Required only when top-ups are enabled (`ENABLE_TOP_UP=true`):
+
+- Ethereum CL RPC service with the debug API available (`/eth/v2/debug/beacon/states`)
+- [Lido Keys API](/guides/tooling/#keys-api) instance
 
 ## How to use
 
@@ -53,7 +70,12 @@ Required variables are(mainnet):
 | CREATE_TRANSACTIONS               | false                                      | If true then tx will be send to blockchain                                                                               |
 | LIDO_LOCATOR                      | 0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb | Lido Locator address. Mainnet by default. Other networks can be found [here](/deployed-contracts/) |
 | DEPOSIT_CONTRACT                  | 0x00000000219ab540356cBB839Cbe05303d7705Fa | Ethereum deposit contract address                                                                                        |
-| DEPOSIT_MODULES_WHITELIST         | 1                                          | List of staking module's ids in which the depositor bot will make deposits                                               |
+| DEPOSIT_MODULES_WHITELIST         | -                                          | Comma separated list of staking module's ids in which the depositor bot will make deposits and top-ups                    |
+| ---                               | ---	                                       | ---                                                                                                                      |
+| ENABLE_TOP_UP                     | false                                      | Enables top-ups of `0x02` modules. Keep disabled until Node Operators submit consolidation requests                       |
+| CL_API_URLS                       | -                                          | Comma separated list of CL endpoints. Required when `ENABLE_TOP_UP=true`                                                  |
+| KEYS_API_URL                      | -                                          | [Keys API](/guides/tooling/#keys-api) URL. Required when `ENABLE_TOP_UP=true`                                             |
+| MAX_VALIDATORS_PER_TOP_UP         | 32                                         | Maximum number of validators per top-up transaction (also capped onchain by the `TopUpGateway`)                           |
 | ---                               | ---	                                       | ---                                                                                                                      |
 | MESSAGE_TRANSPORTS                | -                                          | Transports used in bot. Set: onchain_transport                                                                           |
 | ONCHAIN_TRANSPORT_RPC_ENDPOINTS   | -                                          | List of databus(Gnosis) rpc endpoints that will be used for reading data bus contract, comma separated (`,`).            |
@@ -83,13 +105,15 @@ Optional variables can be found [here](https://github.com/lidofinance/depositor-
     ```
 3. Run depositor bot
     ```bash
-    poetry run python src/depositor.py
+    poetry run python src/main.py depositor
     ```
 4. Verify in logs that depositor bot is performing validations, you should see logs of a kind:
     ```
-    {"name": "bots.depositor", "levelname": "INFO", "funcName": "execute", "lineno": 121, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1729511569, "msg": "Do deposit to module with id: 1."}
-    {"name": "bots.depositor", "levelname": "INFO", "funcName": "_deposit_to_module", "lineno": 210, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1729511569, "msg": "Checks failed. Skip deposit."}
-    {"name": "bots.depositor", "levelname": "INFO", "funcName": "_deposit_to_module", "lineno": 194, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1729511569, "msg": "Calculations deposit recommendations.", "value": false, "is_mellow": false}
+    {"name": "bots.depositor", "levelname": "INFO", "funcName": "execute", "lineno": 210, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1753350000, "msg": "Depositor iteration start.", "block_number": 23000000}
+    {"name": "bots.depositor", "levelname": "INFO", "funcName": "_execute_actual", "lineno": 245, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1753350000, "msg": "Depositable ether.", "value": 3200000000000000000000}
+    {"name": "bots.depositor", "levelname": "INFO", "funcName": "_execute_actual", "lineno": 303, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1753350000, "msg": "Phase B start: full deposits to 0x01 + top-up to 0x02."}
+    {"name": "bots.depositor", "levelname": "INFO", "funcName": "_deposit_to_module", "lineno": 490, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1753350000, "msg": "Gas price too high — skip deposit.", "module_id": 1}
+    {"name": "bots.depositor", "levelname": "INFO", "funcName": "execute", "lineno": 215, "module": "depositor", "pathname": "/app/src/bots/depositor.py", "timestamp": 1753350000, "msg": "Depositor iteration finished.", "value": true}
     ```
 
 If you are facing problems, check what environment variables depositor bot is using, find a log
@@ -101,5 +125,6 @@ Docker image can be found [here](/guides/tooling/#depositor-bot).
 
 ## Monitoring
 
-Prometheus metrics will be available on endpoint `http://localhost:${PROMETHEUS_PORT}/metrics`.
-Alerts [source code](https://github.com/lidofinance/depositor-bot?tab=readme-ov-file#alerts) for AlertManager.
+Prometheus metrics will be available on endpoint `http://localhost:${PROMETHEUS_PORT}/metrics`. The metrics list is
+defined in [src/metrics/metrics.py](https://github.com/lidofinance/depositor-bot/blob/main/src/metrics/metrics.py).
+Alerts [source code](https://github.com/lidofinance/depositor-bot/blob/main/alerts/alerts.yml) for AlertManager.

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -44,11 +44,11 @@ The Lido Council Daemon monitors deposit contract keys.
 
 Bot that submits deposit transactions to the Lido protocol once the Deposit Security Committee quorum is reached.
 
-- **Version**: 5.5.1
-- **Docker image**: sha256:bbacf8afbbb2be8b14efcfa0d03b4e8b01a0abe4ba87793d1684eeff5b4eb1a8, [lidofinance/depositor-bot@sha256-bbacf8afbbb2be8b14efcfa0d03b4e8b01a0abe4ba87793d1684eeff5b4eb1a8](https://hub.docker.com/layers/lidofinance/depositor-bot/5.5.1/images/sha256-bbacf8afbbb2be8b14efcfa0d03b4e8b01a0abe4ba87793d1684eeff5b4eb1a8)
-- **Commit hash**: [lidofinance/depositor-bot@89fbbf8](https://github.com/lidofinance/depositor-bot/commit/89fbbf8deae2b93841f5b657b8865ff3d0c762d5)
-- **Last update date**: 21 April, 2026
-- [**Repository**](https://github.com/lidofinance/depositor-bot/tree/5.5.1)
+- **Version**: 5.6.0
+- **Docker image**: sha256:a8fc015713cf4680bf2d2692de7a295ac99d00d29bb154860c285a44e63e0c32, [lidofinance/depositor-bot@sha256-a8fc015713cf4680bf2d2692de7a295ac99d00d29bb154860c285a44e63e0c32](https://hub.docker.com/layers/lidofinance/depositor-bot/5.6.0/images/sha256-a8fc015713cf4680bf2d2692de7a295ac99d00d29bb154860c285a44e63e0c32)
+- **Commit hash**: [lidofinance/depositor-bot@ccb788e](https://github.com/lidofinance/depositor-bot/commit/ccb788e041cf7a95ff5f9a1894bb67fd5393124c)
+- **Last update date**: 24 July, 2026
+- [**Repository**](https://github.com/lidofinance/depositor-bot/tree/5.6.0)
 - [**Documentation**](/guides/depositor-bot)
 
 ## Reward Distribution Bot


### PR DESCRIPTION
Updates the depositor bot docs to [5.6.0](https://github.com/lidofinance/depositor-bot/tree/5.6.0) (pushed to Docker Hub 24 July 2026, commit `ccb788e`).

Closes ORC-780.

5.6.0 is a large release (94 commits since 5.5.1: `0x02` module support, StakingRouter/DSM v4 only, consolidation indexer, new CL + Keys API providers), so the guide needed more than a version bump.

### `docs/guides/tooling.md`

- version, digest `sha256:a8fc0157…e0c32`, commit hash, date, repo tree link

### `docs/guides/depositor-bot.md`

- **Top-ups documented** — ETH added to already-active validators of `0x02` (compounding) modules via `TopUpGateway`; no guardian quorum required, keeps running while DSM deposits are paused, off by default. Links upstream `docs/depositor-algorithm.md`.
- **Requirements** — added a CL RPC (needs the debug API, `/eth/v2/debug/beacon/states`) and a Keys API instance. Both are **required even when `ENABLE_TOP_UP=false`**: `src/main.py` builds `KeysAPIClient` and `ConsensusClient` unconditionally on the depositor path and runs a chain-id consistency check across EL/CL/KAPI that raises on start up. Only the top-up path actually *uses* them — this is the friction recorded in ORC-775.
- **Envs** — added `ENABLE_TOP_UP`, `CL_API_URLS`, `KEYS_API_URL`, `MAX_VALIDATORS_PER_TOP_UP`; fixed `DEPOSIT_MODULES_WHITELIST`, which no longer defaults to `1` (empty in `variables.py`).
- **Entry point** — `poetry run python src/main.py depositor`; `src/depositor.py` hasn't existed since before 5.5.1.
- **Logs/monitoring** — replaced the log sample (it referenced removed `is_mellow` / mellow direct-deposit messages) with real 5.6.0 lines; fixed the dead `README#alerts` anchor → `alerts/alerts.yml`, added the metrics source link.

### Reviewer notes

- **RAM guidance is qualitative.** The bot pulls the full beacon state as SSZ (`src/providers/consensus.py`), so the 2 GB baseline is clearly insufficient with top-ups on, but upstream publishes no figure and the benchmark test measures only time. If anyone has real numbers from staging, that line should get one.
- **Docs build not run** — `node_modules` isn't installed locally and the config uses `onBrokenLinks`/`onBrokenAnchors: 'throw'`. The one new internal link, `/guides/tooling/#keys-api`, matches the existing `## Keys API` heading and mirrors the `#depositor-bot` pattern already used, but CI should be the confirmation.
- **If ORC-775 is fixed**, the mandatory-CL/KAPI paragraph here needs to flip back to "top-up only". Worth linking the two.
- **Out of scope** — the guide still describes deposits generically, while 5.6.0 dropped StakingRouter/DSM below v4 and removed `DSM.canDeposit`/`canTopUp`. Worth a follow-up if this page is meant to track contract-version requirements.