### PR TITLE
Remove Holesky from the sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -176,7 +176,6 @@ module.exports = {
       items: [
         { type: 'doc', id: 'deployed-contracts/index', label: 'Mainnet' },
         'deployed-contracts/hoodi',
-        'deployed-contracts/holesky',
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Remove the deprecated Holesky deployment from the Deployed contracts sidebar.
- Keep the Holesky deployment page available through direct links, matching Sepolia.

## Why

Hoodi is the active testnet deployment, while Holesky is fully deprecated.