### PR TITLE
update lip status

### DIFF
--- a/docs/lips.md
+++ b/docs/lips.md
@@ -15,14 +15,14 @@ More details on the contribution process and LIPs statuses can be found [here](h
 | LIP&nbsp;# | Title | Author | Discussions&#8209;to |
 |------------|-------|--------|----------------|
 | [36](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-36.md) | NEST — Automated LDO Buyback and Liquidity Provisioning System | Vasiliy Shapovalov, Vitaly Galaichuk, Jen Kopytina, Alexander Belokon, adcv | [Link](https://research.lido.fi/t/liquid-buybacks-nest-execution-with-ldo-wsteth-liquidity/10894) |
-| [35](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-35.md) | Staking Router v3 | Maksim Kuraian (@mkurayan) , KRogLA (@KRogLA), Alexander Kolesnikov (@eddort), Anna Mukharram (@Amuhar) | [Link](https://research.lido.fi/t/staking-router-v3-design-implementation-proposal-lip-35/11621) |
-| [33](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-33.md) | Community Staking Module v3 and Curated Module v2 | Dmitry Gusakov (@dgusakov), Sergey Khomutinin (@skhomuti), Dmitry Chernukhin (@madlabman), Vladimir Gorkavenko (@vgorkavenko) | [Link 1](https://research.lido.fi/t/community-staking-module/5917), [Link 2](https://research.lido.fi/t/future-of-the-curated-module-cmv2-landscape/10929) |
 
 ## Implemented
 
 | LIP&nbsp;# | Title | Author | Discussions&#8209;to |
 |------------|-------|--------|----------------|
+| [35](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-35.md) | Staking Router v3 | Maksim Kuraian (@mkurayan) , KRogLA (@KRogLA), Alexander Kolesnikov (@eddort), Anna Mukharram (@Amuhar) | [Link](https://research.lido.fi/t/staking-router-v3-design-implementation-proposal-lip-35/11621) |
 | [34](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-34.md) | CircuitBreaker — Programmable panic layer | Azat Serikov | [Link](https://research.lido.fi/t/circuitbreaker-programmable-panic-layer/11400) |
+| [33](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-33.md) | Community Staking Module v3 and Curated Module v2 | Dmitry Gusakov (@dgusakov), Sergey Khomutinin (@skhomuti), Dmitry Chernukhin (@madlabman), Vladimir Gorkavenko (@vgorkavenko) | [Link 1](https://research.lido.fi/t/community-staking-module/5917), [Link 2](https://research.lido.fi/t/future-of-the-curated-module-cmv2-landscape/10929) |
 | [32](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-32.md) | Sanity Checks for stVaults | Alexander Drygin, Greg Shestakov, Victor Petrenko | [Link](https://research.lido.fi/t/lido-v3-design-implementation-proposal/10665) |
 | [31](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-31.md) | Expanding stETH liquidity layer with over-collateralized minting | Alexei Potapkin, Eugene Mamin, Eugene Pshenichnyy, Max Merkulov | [Link](https://research.lido.fi/t/lido-v3-design-implementation-proposal/10665) |
 | [30](https://github.com/lidofinance/lido-improvement-proposals/blob/develop/LIPS/lip-30.md) | Triggerable Withdrawals Framework | Raman Siamionau, Evgeniy Pirogov | [Link](https://research.lido.fi/t/triggerable-withdrawals-framework-in-the-lido-protocol/10299) |


### PR DESCRIPTION
This pull request updates the Lido Improvement Proposals (LIPs) documentation to reflect the implementation status of two proposals. Specifically, LIP-35 and LIP-33 have been moved from the proposed section to the implemented section.

LIP status updates:

* Moved LIP-35 (Staking Router v3) from the proposed section to the implemented section in `docs/lips.md`.
* Moved LIP-33 (Community Staking Module v3 and Curated Module v2) from the proposed section to the implemented section in `docs/lips.md`.