### PR TITLE
Document bug bounty program track record

### DIFF
--- a/docs/security/bugbounty.md
+++ b/docs/security/bugbounty.md
@@ -1,9 +1,28 @@
-# Bug Bounties with Immunefi
+# Bug Bounty Program with Immunefi
 
 ## Program overview
 
-Lido Bug Bounty programs allow you to report a vulnerability and get up to $2,000,000.
+The Lido bug bounty program has operated on Immunefi since May 2021. It helps protect user funds, protocol governance, and the applications and infrastructure that support the protocol.
 
-We’re using the [Immunefi platform](https://immunefi.com/bounty/lido/) — the leading bug bounty platform for DeFi with the world's largest bounties.
+Researchers can receive rewards of up to $2,000,000. The current assets, impacts, reward levels, and submission requirements are available on the [Lido program page on Immunefi](https://immunefi.com/bug-bounty/lido/information/).
 
-[Lido Bug Bounty program](https://immunefi.com/bug-bounty/lido/information/) focused on the prevention of loss of user funds, denial of service, governance hijacks, data breaches, and data leaks. We care about it and have already paid more than $350,000 for 10 Bug Bounties.
+## Program track record
+
+As of August 19, 2026, the program has:
+
+- rewarded 43 reports;
+- paid more than $395,000 to security researchers.
+
+These figures use the **All Time** view in Immunefi program analytics. The payout total is rounded down. A rewarded report is a report recorded as paid in those analytics.
+
+Published [security disclosures](/security/disclosures) provide details about findings that are safe to discuss after remediation.
+
+## How reports are assessed
+
+Reports are assessed against their demonstrated impact, reproducibility, and the published program rules. The claimed severity is a starting point; the final assessment depends on the effect that the report can have on the protocol or an in-scope application.
+
+Formal scope keeps expectations clear, but it does not capture every useful security contribution. Contributors have also made discretionary payments for reports outside the formal scope when the work introduced valuable security considerations or new ways to assess risk.
+
+## Submit a report
+
+Review the current scope and submit reports through the [Lido program page on Immunefi](https://immunefi.com/bug-bounty/lido/information/). Do not disclose a suspected vulnerability publicly before it is resolved and approved for disclosure.


### PR DESCRIPTION
## 📝 Describe your changes

1. Records that the Lido bug bounty program has operated on Immunefi since May 2021.
2. Updates the cumulative track record to 43 rewarded reports and more than $395,000 paid as of August 19, 2026.
3. Explains the assessment criteria and the use of discretionary payments for valuable reports outside formal scope.
4. Adds links to the current Immunefi program and published security disclosures.

## 🔎 Source of truth and evidence

1. The public Immunefi program data records a launch date of May 22, 2021 and the current program terms: https://immunefi.com/bug-bounty/lido/information/
2. The cumulative figures come from the **All Time** view in Immunefi program analytics captured on August 19, 2026. The displayed severity cells independently sum to 625 reports and 43 rewarded reports; the displayed payout total is $395k+. The docs round that total down.
3. The PR contains no report identifiers, individual amounts, affected-component details, or unresolved findings.