### PR TITLE
docs: update Token Rate Notifier addresses

### DIFF
--- a/docs/deployed-contracts/hoodi.md
+++ b/docs/deployed-contracts/hoodi.md
@@ -6,7 +6,7 @@ Hoodi is the primary operational and actively maintained Lido protocol testnet. 
 
 **Deployment Information:**
 
-- ⚓ Lido protocol version: [**`v4.0.0`**](https://github.com/lidofinance/core/releases/tag/v4.0.0)
+- ⚓ Lido protocol version: [**`v4.0.1`**](https://github.com/lidofinance/core/releases/tag/v4.0.1)
 - 🌐 Network: Ethereum Hoodi (Chain ID: `560048`)
 - ✅ Status: Active and maintained
 
@@ -161,7 +161,7 @@ Each pausable contract below is covered by the CircuitBreaker and has a designat
 
 ## 🔄 Post Token Rebase Receiver {#post-token-rebase-receiver}
 
-- Token Rate Notifier: [`0x9c53d0075eA00ad77dDAd1b71E67bb97AaBC1e3D`](https://hoodi.etherscan.io/address/0x9c53d0075eA00ad77dDAd1b71E67bb97AaBC1e3D)
+- Token Rate Notifier: [`0xe2d1307a8e0eb6996eE9eB6FB5949124F17EDf65`](https://hoodi.etherscan.io/address/0xe2d1307a8e0eb6996eE9eB6FB5949124F17EDf65)
 
 ## 🧩 Staking Modules {#staking-modules}
 

--- a/docs/deployed-contracts/index.md
+++ b/docs/deployed-contracts/index.md
@@ -10,7 +10,7 @@ This page lists production contract addresses on mainnets, including Ethereum an
 
 **Deployment Information:**
 
-- ⚓ Lido protocol version: [**`v4.0.0`**](https://github.com/lidofinance/core/releases/tag/v4.0.0)
+- ⚓ Lido protocol version: [**`v4.0.1`**](https://github.com/lidofinance/core/releases/tag/v4.0.1)
 - 🌐 Network: Ethereum Mainnet (Chain ID: `1`)
 - ✅ Status: Active and maintained
 :::
@@ -162,7 +162,7 @@ Each pausable contract below is covered by the CircuitBreaker, with a designated
 
 ## 🔄 Post Token Rebase Receiver {#post-token-rebase-receiver}
 
-- Token Rate Notifier: [`0x25e35855783bec3E49355a29e110f02Ed8b05ba9`](https://etherscan.io/address/0x25e35855783bec3E49355a29e110f02Ed8b05ba9)
+- Token Rate Notifier: [`0xbe05d12Fd10919F1881125006523452F6aFF791b`](https://etherscan.io/address/0xbe05d12Fd10919F1881125006523452F6aFF791b)
 
 ## 🧩 Staking Modules {#staking-modules}
 


### PR DESCRIPTION
## Please, go through these steps before you request a review:

### 📝 Describe your changes
1. Update the Mainnet and Hoodi Token Rate Notifier addresses to the active `postTokenRebaseReceiver` values.
2. Bump the listed Lido protocol version to `v4.0.1`.

### 🔎 Attach a source of truth or evidence that allows reviewers to confirm the changes independently
1. [core v4.0.1 release](https://github.com/lidofinance/core/releases/tag/v4.0.1)
2. [Mainnet deployment artifact](https://github.com/lidofinance/core/blob/v4.0.1/deployed-mainnet.json)
3. [Hoodi deployment artifact](https://github.com/lidofinance/core/blob/v4.0.1/deployed-hoodi.json)