### PR TITLE
docs: add manual security disclosure collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This refreshes the audit and LIP indexes, then checks documented Safe multisig q
 
 ### Review disclosure candidates
 
-Run the separate manual collector to compare likely security disclosures on the [Lido Research Forum](https://research.lido.fi) with `docs/security/disclosures.md`:
+Run the separate manual collector to find security disclosures relevant to Lido's staking business on the [Lido Research Forum](https://research.lido.fi) and compare them with `docs/security/disclosures.md`:
 
 ```console
 npm run fetch-disclosures
@@ -124,6 +124,6 @@ The default window starts at the latest publication date in the local ledger and
 
 Reports are written to timestamped JSON files in the already-ignored `.security-triage/` directory. They contain numeric ids, source links, dates, content hashes, candidates, already-listed topics, routing exclusions, and coverage errors. Titles, post bodies, and author identities are not saved. Compare ledger links by topic id, so links to individual replies do not create duplicate candidates.
 
-Selection uses title terms such as security disclosure, security bulletin, incident, post-mortem, and vulnerability. Node-operator-category topics and topics mentioning Lido Earn/earnETH/earnUSD in their title or opening post are routed to exclusions for human review. Other product incidents must also be excluded during review. These are heuristics: a complete collection means pagination and selected post streams succeeded, not that every disclosure was discovered. Unbumped edits and disclosures without matching title terms can be missed; use overlapping windows and inspect exclusions before publishing.
+Selection uses title terms such as security disclosure, security bulletin, incident, post-mortem, vulnerability/vulnerabilities, and weakness/weaknesses. The ledger focuses on Lido's staking business; a maintainer confirms each candidate's relevance before inclusion. Node-operator-category topics and topics mentioning Lido Earn/earnETH/earnUSD in their title or opening post are routed to exclusions for human review. These are heuristics: a complete collection means pagination and selected post streams succeeded, not that every disclosure was discovered. Unbumped edits and disclosures without matching title terms can be missed; use overlapping windows and inspect exclusions before publishing.
 
 This command produces review candidates only. A maintainer chooses the scope, publication date, type, severity, and wording before manually editing the ledger. It does not run through `npm run fetch` or fetch live forum data during tests, builds, or deployment.

--- a/README.md
+++ b/README.md
@@ -110,3 +110,20 @@ npm run fetch
 ```
 
 This refreshes the audit and LIP indexes, then checks documented Safe multisig quorums against public chain RPC endpoints. Use `npm run fetch-audits`, `npm run fetch-lips`, or `npm run fetch-msig-quorums` to run one task.
+
+### Review disclosure candidates
+
+Run the separate manual collector to compare likely security disclosures on the [Lido Research Forum](https://research.lido.fi) with `docs/security/disclosures.md`:
+
+```console
+npm run fetch-disclosures
+npm run fetch-disclosures -- --since 2026-03-23 --until 2026-09-11
+```
+
+The default window starts at the latest publication date in the local ledger and ends today, inclusive in UTC. Use an earlier `--since` for a historical sweep. The collector follows the [Discourse API](https://docs.discourse.org/) latest-topic pagination and fetches the complete post stream of every keyword-matched topic, including additional post batches. It uses the shared HTTP and task helpers. `--max-pages N` defaults to 50; reaching that limit without exhausting the window, invalid data, or a failed request produces an incomplete report and a nonzero exit status.
+
+Reports are written to timestamped JSON files in the already-ignored `.security-triage/` directory. They contain numeric ids, source links, dates, content hashes, candidates, already-listed topics, routing exclusions, and coverage errors. Titles, post bodies, and author identities are not saved. Compare ledger links by topic id, so links to individual replies do not create duplicate candidates.
+
+Selection uses title terms such as security disclosure, security bulletin, incident, post-mortem, and vulnerability. Node-operator-category topics and topics mentioning Lido Earn/earnETH/earnUSD in their title or opening post are routed to exclusions for human review. Other product incidents must also be excluded during review. These are heuristics: a complete collection means pagination and selected post streams succeeded, not that every disclosure was discovered. Unbumped edits and disclosures without matching title terms can be missed; use overlapping windows and inspect exclusions before publishing.
+
+This command produces review candidates only. A maintainer chooses the scope, publication date, type, severity, and wording before manually editing the ledger. It does not run through `npm run fetch` or fetch live forum data during tests, builds, or deployment.

--- a/docs/security/disclosures.md
+++ b/docs/security/disclosures.md
@@ -2,8 +2,11 @@
 
 A reverse-chronological (most recent first) record of security-related disclosures and post-mortem reports published by Lido. For details on impact, root cause, and resolution, refer to the linked reports. Dates reflect when the report was published. Disclosures and outage reports related to node operators can be found on [research.lido.fi](https://research.lido.fi).
 
+Product-level incidents, including Lido Earn incidents, are outside the scope of this ledger.
+
 | Date | Type | Severity | Title | Links |
 | ---------- | ---- | -------- | --------------------------------------------------- | ----- |
+| 2026-08-06 | Incident | Low | Staking Router v3: Accounting Oracle / VEBO Incident | [Forum](https://research.lido.fi/t/11756/3) |
 | 2026-03-23 | Bug Bounty | Low | Batched Immunefi-reported Weakness Disclosure | [Forum](https://research.lido.fi/t/security-bulletin-batched-immunefi-reported-weakness-disclosure-march-2026-funds-not-at-risk/11342) |
 | 2025-08-01 | Bug Bounty | High | CSVerifier Weak Validation of Historical Block GIndex | [Forum](https://research.lido.fi/t/security-disclosure-post-mortem-csverifier-weak-validation-of-the-historical-block-gindex-user-funds-remain-safe/10466) |
 | 2025-07-21 | Bug Bounty | Moderate | DG Weakness Reported Through Immunefi | [Forum](https://research.lido.fi/t/security-disclosure-dg-weakness-reported-through-immunefi-funds-not-at-risk/10393) |
@@ -17,4 +20,4 @@ A reverse-chronological (most recent first) record of security-related disclosur
 
 *Severity levels: **Critical** — potential loss of staker funds or critical system compromise. **High** — significant impact, may affect funds under specific conditions. **Moderate** — limited impact, staker funds not at risk. **Low** — minimal impact, informational or theoretical.*
 
-*Last updated: 24 Mar 2026*
+*Last updated: 11 Sep 2026*

--- a/docs/security/disclosures.md
+++ b/docs/security/disclosures.md
@@ -2,7 +2,7 @@
 
 A reverse-chronological (most recent first) record of security-related disclosures and post-mortem reports published by Lido. For details on impact, root cause, and resolution, refer to the linked reports. Dates reflect when the report was published. Disclosures and outage reports related to node operators can be found on [research.lido.fi](https://research.lido.fi).
 
-Product-level incidents, including Lido Earn incidents, are outside the scope of this ledger.
+This ledger focuses on security-related disclosures affecting Lido's staking business.
 
 | Date | Type | Severity | Title | Links |
 | ---------- | ---- | -------- | --------------------------------------------------- | ----- |
@@ -20,4 +20,4 @@ Product-level incidents, including Lido Earn incidents, are outside the scope of
 
 *Severity levels: **Critical** — potential loss of staker funds or critical system compromise. **High** — significant impact, may affect funds under specific conditions. **Moderate** — limited impact, staker funds not at risk. **Low** — minimal impact, informational or theoretical.*
 
-*Last updated: 11 Sep 2026*
+*Last updated: 12 Sep 2026*

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fetch": "node scripts/fetch.js",
     "fetch-audits": "node scripts/fetch-audits.js",
     "fetch-lips": "node scripts/fetch-lips.js",
+    "fetch-disclosures": "node scripts/fetch-disclosures.js",
     "fetch-msig-quorums": "node scripts/fetch-msig-quorums.js"
   },
   "dependencies": {

--- a/scripts/fetch-disclosures.js
+++ b/scripts/fetch-disclosures.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { fetchJson } = require('./lib/http')
+const { scanMarkdownTables } = require('./lib/markdown')
+const { runTask } = require('./lib/tasks')
+
+const FORUM_URL = 'https://research.lido.fi'
+const LEDGER_PATH = path.join(__dirname, '../docs/security/disclosures.md')
+const REPORT_DIRECTORY = path.join(__dirname, '../.security-triage')
+const NODE_OPERATOR_CATEGORY = 12
+const POST_BATCH_SIZE = 20
+
+function hash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+function validateDate(value) {
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`invalid date: ${value}; expected YYYY-MM-DD`)
+  }
+  return value
+}
+
+function readLedger(markdown) {
+  const dates = []
+  const topicIds = new Set()
+  for (const table of scanMarkdownTables(markdown.split('\n'))) {
+    const dateColumn = table.headers.indexOf('Date')
+    const linksColumn = table.headers.indexOf('Links')
+    if (dateColumn === -1 || linksColumn === -1) continue
+    for (const { cells } of table.rows) {
+      dates.push(validateDate(cells[dateColumn]))
+      for (const match of (cells[linksColumn] || '').matchAll(/https:\/\/research\.lido\.fi\/t\/[^\s)]+/g)) {
+        const segments = new URL(match[0]).pathname.split('/').filter(Boolean)
+        const id = /^\d+$/.test(segments[1]) ? segments[1] : segments[2]
+        if (/^\d+$/.test(id || '')) topicIds.add(Number(id))
+      }
+    }
+  }
+  if (!dates.length) throw new Error('no dated disclosure ledger rows found')
+  return { latestDate: dates.sort().at(-1), topicIds }
+}
+
+function parseOptions(argv, latestDate) {
+  const options = { since: latestDate, until: new Date().toISOString().slice(0, 10), maxPages: 50 }
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index]
+    const value = argv[index + 1]
+    if (!['--since', '--until', '--max-pages'].includes(flag) || value === undefined) {
+      throw new Error('usage: npm run fetch-disclosures -- [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--max-pages N]')
+    }
+    if (flag === '--max-pages') {
+      if (!/^[1-9]\d*$/.test(value) || !Number.isSafeInteger(Number(value)))
+        throw new Error('max-pages must be a positive integer')
+      options.maxPages = Number(value)
+    } else options[flag.slice(2)] = validateDate(value)
+  }
+  if (options.since > options.until) throw new Error('since must not be after until')
+  return options
+}
+
+function classifyTopic(title, categoryId, openingText = '') {
+  const normalized = title.toLowerCase().replace(/[^a-z0-9]+/g, ' ')
+  if (
+    !/\b(security disclosure|security bulletin|incident|post mortem|postmortem|vulnerabilit(?:y|ies))\b/.test(
+      normalized,
+    )
+  )
+    return null
+  if (categoryId === NODE_OPERATOR_CATEGORY) return 'node_operator'
+  const context = `${normalized} ${openingText.toLowerCase().replace(/<[^>]*>/g, ' ')}`
+  if (/\b(lido earn|earneth|earnusd)\b/.test(context)) return 'product'
+  return /\bsecurity (disclosure|bulletin)\b/.test(normalized) ? 'explicit_disclosure' : 'review_required'
+}
+
+async function fetchTopic(topicId, getJson) {
+  const topic = await getJson(`${FORUM_URL}/t/${topicId}.json`)
+  const stream = topic.post_stream?.stream
+  const initial = topic.post_stream?.posts
+  if (
+    topic.id !== topicId ||
+    !Array.isArray(stream) ||
+    !stream.length ||
+    !stream.every(Number.isSafeInteger) ||
+    new Set(stream).size !== stream.length ||
+    !Array.isArray(initial)
+  ) {
+    throw new Error(`invalid post stream for topic ${topicId}`)
+  }
+  const posts = new Map(initial.map((post) => [post.id, post]))
+  const missing = stream.filter((id) => !posts.has(id))
+  for (let offset = 0; offset < missing.length; offset += POST_BATCH_SIZE) {
+    const query = new URLSearchParams(
+      missing.slice(offset, offset + POST_BATCH_SIZE).map((id) => ['post_ids[]', String(id)]),
+    )
+    const batch = await getJson(`${FORUM_URL}/t/${topicId}/posts.json?${query}`)
+    if (!Array.isArray(batch.post_stream?.posts)) throw new Error(`invalid post batch for topic ${topicId}`)
+    for (const post of batch.post_stream.posts) posts.set(post.id, post)
+  }
+  const pins = stream.map((id) => {
+    const post = posts.get(id)
+    if (!post || !Number.isSafeInteger(post.post_number) || typeof post.cooked !== 'string') {
+      throw new Error(`missing or invalid post ${id} in topic ${topicId}`)
+    }
+    return { id, number: post.post_number, updated_at: post.updated_at, content_sha256: hash(post.cooked) }
+  })
+  const firstPost = [...posts.values()].find((post) => post.post_number === 1)
+  if (!firstPost || typeof topic.title !== 'string')
+    throw new Error(`missing opening post or title for topic ${topicId}`)
+  return {
+    topic_id: topicId,
+    source: `${FORUM_URL}/t/${topicId}`,
+    category_id: topic.category_id,
+    classification: classifyTopic(topic.title, topic.category_id, firstPost.cooked),
+    created_at: topic.created_at,
+    last_posted_at: topic.last_posted_at,
+    complete_post_stream: true,
+    post_count: pins.length,
+    post_set_sha256: hash(JSON.stringify(pins)),
+    posts: pins,
+  }
+}
+
+async function collectDisclosures(options, ledgerMarkdown, getJson = fetchJson) {
+  const ledger = readLedger(ledgerMarkdown)
+  const report = {
+    schema_version: 1,
+    fetched_at: new Date().toISOString(),
+    since: options.since,
+    until: options.until,
+    selection: 'Title keywords on topics bumped within the inclusive UTC date window; manual review required.',
+    ledger_sha256: hash(ledgerMarkdown),
+    pages_fetched: 0,
+    page_payload_sha256: [],
+    discovery_complete: false,
+    stop_reason: 'max_pages',
+    candidates: [],
+    already_listed: [],
+    exclusions: [],
+    errors: [],
+  }
+  const selected = new Set()
+  const seen = new Set()
+  for (let page = 0; page < options.maxPages; page += 1) {
+    try {
+      const listing = await getJson(`${FORUM_URL}/latest.json?page=${page}&order=activity`)
+      const topics = listing.topic_list?.topics
+      if (!Array.isArray(topics)) throw new Error('invalid latest-topic listing')
+      report.pages_fetched += 1
+      report.page_payload_sha256.push(hash(JSON.stringify(listing)))
+      if (!topics.length) {
+        report.discovery_complete = true
+        report.stop_reason = 'empty_page'
+        break
+      }
+      const activityDates = []
+      let newTopics = 0
+      for (const topic of topics) {
+        if (!Number.isSafeInteger(topic.id) || typeof topic.title !== 'string')
+          throw new Error('invalid topic metadata')
+        const activity = validateDate((topic.bumped_at || topic.last_posted_at || topic.created_at || '').slice(0, 10))
+        if (!topic.pinned) activityDates.push(activity)
+        if (!seen.has(topic.id)) newTopics += 1
+        seen.add(topic.id)
+        if (options.since <= activity && activity <= options.until && classifyTopic(topic.title, topic.category_id)) {
+          selected.add(topic.id)
+        }
+      }
+      // An old pinned topic must not make the scan stop before later pages.
+      if (activityDates.length && activityDates.every((date) => date < options.since)) {
+        report.discovery_complete = true
+        report.stop_reason = 'window_exhausted'
+        break
+      }
+      if (!newTopics) throw new Error('pagination repeated without progress')
+    } catch (error) {
+      report.errors.push({ page, message: error.message })
+      report.stop_reason = 'fetch_error'
+      break
+    }
+  }
+  for (const topicId of [...selected].sort((a, b) => a - b)) {
+    try {
+      const topic = await fetchTopic(topicId, getJson)
+      if (['product', 'node_operator'].includes(topic.classification)) report.exclusions.push(topic)
+      else if (ledger.topicIds.has(topicId)) report.already_listed.push(topic)
+      else if (topic.classification) report.candidates.push(topic)
+      else report.exclusions.push({ ...topic, classification: 'title_changed' })
+    } catch (error) {
+      report.errors.push({ topic_id: topicId, message: error.message })
+    }
+  }
+  report.collection_complete = report.discovery_complete && report.errors.length === 0
+  return report
+}
+
+async function run() {
+  const ledgerMarkdown = fs.readFileSync(LEDGER_PATH, 'utf8')
+  const options = parseOptions(process.argv.slice(2), readLedger(ledgerMarkdown).latestDate)
+  const report = await collectDisclosures(options, ledgerMarkdown)
+  fs.mkdirSync(REPORT_DIRECTORY, { recursive: true })
+  const output = path.join(REPORT_DIRECTORY, `disclosures-${report.fetched_at.replace(/[:.]/g, '-')}.json`)
+  fs.writeFileSync(output, JSON.stringify(report, null, 2) + '\n', { encoding: 'utf8', flag: 'wx' })
+  console.log(`Disclosure candidates written → ${output}`)
+  console.log(
+    `candidates=${report.candidates.length} already_listed=${report.already_listed.length} excluded=${report.exclusions.length} complete=${report.collection_complete} errors=${report.errors.length}`,
+  )
+  for (const error of report.errors) console.error(JSON.stringify(error))
+  return report.collection_complete ? 0 : 1
+}
+
+if (require.main === module) runTask(run)
+
+module.exports = { classifyTopic, collectDisclosures, fetchTopic, parseOptions, readLedger, run }

--- a/scripts/fetch-disclosures.js
+++ b/scripts/fetch-disclosures.js
@@ -70,7 +70,7 @@ function parseOptions(argv, latestDate) {
 function classifyTopic(title, categoryId, openingText = '') {
   const normalized = title.toLowerCase().replace(/[^a-z0-9]+/g, ' ')
   if (
-    !/\b(security disclosure|security bulletin|incident|post mortem|postmortem|vulnerabilit(?:y|ies))\b/.test(
+    !/\b(security disclosure|security bulletin|incident|post mortem|postmortem|vulnerabilit(?:y|ies)|weakness(?:es)?)\b/.test(
       normalized,
     )
   )

--- a/tests/fetch-disclosures.test.js
+++ b/tests/fetch-disclosures.test.js
@@ -82,6 +82,29 @@ test('classifies candidates with product and node-operator routing precedence', 
   assert.equal(classifyTopic('Routine update', 1), null)
 })
 
+test('discovers weakness-only titles while retaining product and operator routing', async () => {
+  const titles = ['Recovery-lever weakness', 'Accounting weaknesses', 'Lido Earn weakness', 'Validator weakness']
+  const listings = titles.map((title, index) => listingTopic(43 + index, { title, category_id: index === 3 ? 12 : 1 }))
+  const topics = Object.fromEntries(listings.map((item) => [item.id, topic(item.id, item)]))
+  const report = await collectDisclosures(OPTIONS, LEDGER, api([listings], topics))
+
+  assert.equal(report.collection_complete, true)
+  assert.deepEqual(
+    report.candidates.map((row) => [row.topic_id, row.classification]),
+    [
+      [43, 'review_required'],
+      [44, 'review_required'],
+    ],
+  )
+  assert.deepEqual(
+    report.exclusions.map((row) => [row.topic_id, row.classification]),
+    [
+      [45, 'product'],
+      [46, 'node_operator'],
+    ],
+  )
+})
+
 test('fetches all missing post batches and retains hashes without text or identities', async () => {
   const posts = Array.from({ length: 23 }, (_, index) => ({
     id: index + 1,

--- a/tests/fetch-disclosures.test.js
+++ b/tests/fetch-disclosures.test.js
@@ -1,0 +1,245 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+
+const {
+  classifyTopic,
+  collectDisclosures,
+  fetchTopic,
+  parseOptions,
+  readLedger,
+  run,
+} = require('../scripts/fetch-disclosures')
+
+const LEDGER = `# Security Disclosures
+| Date | Type | Severity | Title | Links |
+| --- | --- | --- | --- | --- |
+| 2026-03-23 | Bug Bounty | Low | Bulletin | [Forum](https://research.lido.fi/t/bulletin/42/3) |
+`
+const OPTIONS = { since: '2026-03-23', until: '2026-09-11', maxPages: 5 }
+
+function listingTopic(id, overrides = {}) {
+  return { id, title: 'Security Disclosure', category_id: 1, bumped_at: '2026-08-06T00:00:00Z', ...overrides }
+}
+
+function topic(id, overrides = {}) {
+  return {
+    ...listingTopic(id),
+    title: 'Security Disclosure',
+    post_stream: {
+      stream: [id * 10],
+      posts: [{ id: id * 10, post_number: 1, username: 'not-retained', cooked: '<p>Protocol report.</p>' }],
+    },
+    ...overrides,
+  }
+}
+
+function api(pages, topics) {
+  return async (url) => {
+    const parsed = new URL(url)
+    if (parsed.pathname === '/latest.json')
+      return { topic_list: { topics: pages[Number(parsed.searchParams.get('page'))] || [] } }
+    const id = Number(parsed.pathname.match(/\/t\/(\d+)/)[1])
+    if (!topics[id]) throw new Error('HTTP 503')
+    return topics[id]
+  }
+}
+
+test('reads ledger dates and deduplicates slugged, numeric, and reply topic links', () => {
+  const markdown =
+    LEDGER +
+    '| 2026-08-06 | Incident | Low | Report | [Forum](https://research.lido.fi/t/43/3) [Duplicate](https://research.lido.fi/t/name/43) |\n'
+  const ledger = readLedger(markdown)
+  assert.equal(ledger.latestDate, '2026-08-06')
+  assert.deepEqual([...ledger.topicIds], [42, 43])
+  assert.throws(() => readLedger('# Empty ledger'), /no dated/)
+})
+
+test('validates manual date windows and pagination limits', () => {
+  assert.equal(parseOptions([], '2026-03-23').since, '2026-03-23')
+  assert.deepEqual(parseOptions(['--until', '2026-09-11', '--max-pages', '7'], '2026-03-23'), {
+    ...OPTIONS,
+    maxPages: 7,
+  })
+  for (const argv of [
+    ['--since', '2026-02-30'],
+    ['--max-pages', '0'],
+    ['--until', '2025-01-01'],
+    ['--write'],
+    ['--unknown', '1'],
+  ]) {
+    assert.throws(() => parseOptions(argv, '2026-03-23'))
+  }
+})
+
+test('classifies candidates with product and node-operator routing precedence', () => {
+  assert.equal(classifyTopic('Security disclosure', 12), 'node_operator')
+  assert.equal(classifyTopic('Lido Earn security bulletin', 1), 'product')
+  assert.equal(classifyTopic('Loss coverage for an incident', 9, '<p>Lido Earn contributors report...</p>'), 'product')
+  assert.equal(classifyTopic('Security bulletin', 1), 'explicit_disclosure')
+  assert.equal(classifyTopic('Post-mortem', 1), 'review_required')
+  assert.equal(classifyTopic('New vulnerabilities', 1), 'review_required')
+  assert.equal(classifyTopic('Routine update', 1), null)
+})
+
+test('fetches all missing post batches and retains hashes without text or identities', async () => {
+  const posts = Array.from({ length: 23 }, (_, index) => ({
+    id: index + 1,
+    post_number: index + 1,
+    cooked: 'private-body',
+    username: 'private-identity',
+  }))
+  const requests = []
+  const result = await fetchTopic(42, async (url) => {
+    requests.push(url)
+    if (url.endsWith('/42.json'))
+      return topic(42, {
+        title: 'Security Disclosure private-title',
+        post_stream: { stream: posts.map((post) => post.id), posts: [posts[0]] },
+      })
+    const ids = new URL(url).searchParams.getAll('post_ids[]').map(Number)
+    return { post_stream: { posts: posts.filter((post) => ids.includes(post.id)) } }
+  })
+  assert.equal(requests.length, 3)
+  assert.equal(result.post_count, 23)
+  assert.equal(result.complete_post_stream, true)
+  assert.match(result.post_set_sha256, /^[a-f0-9]{64}$/)
+  assert.doesNotMatch(JSON.stringify(result), /private-body|private-title|private-identity|username|cooked/)
+})
+
+test('rejects missing posts, empty streams, and mismatched topic ids', async () => {
+  await assert.rejects(
+    fetchTopic(42, async () => topic(43)),
+    /invalid post stream/,
+  )
+  await assert.rejects(
+    fetchTopic(42, async () => topic(42, { post_stream: { stream: [], posts: [] } })),
+    /invalid post stream/,
+  )
+  await assert.rejects(
+    fetchTopic(42, async (url) =>
+      url.endsWith('/42.json')
+        ? topic(42, { post_stream: { stream: [1, 2], posts: [{ id: 1, post_number: 1, cooked: 'Report' }] } })
+        : { post_stream: { posts: [] } },
+    ),
+    /missing or invalid post 2/,
+  )
+})
+
+test('old pinned topics do not truncate discovery; repeated ids produce one candidate', async () => {
+  const pages = [
+    [listingTopic(1, { pinned: true, bumped_at: '2020-01-01T00:00:00Z' }), listingTopic(42)],
+    [listingTopic(43), listingTopic(43)],
+    [],
+  ]
+  const report = await collectDisclosures(OPTIONS, LEDGER, api(pages, { 42: topic(42), 43: topic(43) }))
+  assert.equal(report.collection_complete, true)
+  assert.equal(report.pages_fetched, 3)
+  assert.deepEqual(
+    report.candidates.map((row) => row.topic_id),
+    [43],
+  )
+  assert.deepEqual(
+    report.already_listed.map((row) => row.topic_id),
+    [42],
+  )
+})
+
+test('routes product incidents discovered from opening posts and excludes node-operator incidents', async () => {
+  const report = await collectDisclosures(
+    OPTIONS,
+    LEDGER,
+    api([[listingTopic(43), listingTopic(44)]], {
+      43: topic(43, {
+        post_stream: {
+          stream: [430],
+          posts: [{ id: 430, post_number: 1, cooked: 'Lido Earn contributors report an incident.' }],
+        },
+      }),
+      44: topic(44, { category_id: 12 }),
+    }),
+  )
+  assert.equal(report.candidates.length, 0)
+  assert.deepEqual(
+    report.exclusions.map((row) => row.classification),
+    ['product', 'node_operator'],
+  )
+  assert.equal(report.collection_complete, true)
+})
+
+test('bounds discovery by inclusive activity dates', async () => {
+  const pages = [
+    [listingTopic(43, { bumped_at: '2026-03-23T23:59:59Z' }), listingTopic(44, { bumped_at: '2026-09-12T00:00:00Z' })],
+    [listingTopic(45, { bumped_at: '2026-03-22T00:00:00Z' })],
+  ]
+  const report = await collectDisclosures(OPTIONS, LEDGER, api(pages, { 43: topic(43) }))
+  assert.equal(report.stop_reason, 'window_exhausted')
+  assert.deepEqual(
+    report.candidates.map((row) => row.topic_id),
+    [43],
+  )
+})
+
+test('page limits and HTTP errors produce incomplete reports with discovered candidates retained', async () => {
+  const limited = await collectDisclosures(
+    { ...OPTIONS, maxPages: 1 },
+    LEDGER,
+    api([[listingTopic(43)]], { 43: topic(43) }),
+  )
+  assert.equal(limited.collection_complete, false)
+  assert.equal(limited.stop_reason, 'max_pages')
+  assert.equal(limited.candidates.length, 1)
+  const failed = await collectDisclosures(OPTIONS, LEDGER, async () => {
+    throw new Error('HTTP 429')
+  })
+  assert.equal(failed.collection_complete, false)
+  assert.match(failed.errors[0].message, /HTTP 429/)
+  const missingTopic = await collectDisclosures(OPTIONS, LEDGER, api([[listingTopic(43)]], {}))
+  assert.equal(missingTopic.discovery_complete, true)
+  assert.equal(missingTopic.collection_complete, false)
+  assert.equal(missingTopic.errors[0].topic_id, 43)
+})
+
+test('repeated pagination is an error rather than complete coverage', async () => {
+  const report = await collectDisclosures(
+    OPTIONS,
+    LEDGER,
+    api([[listingTopic(43)], [listingTopic(43)]], { 43: topic(43) }),
+  )
+  assert.equal(report.collection_complete, false)
+  assert.match(report.errors[0].message, /without progress/)
+})
+
+test('run returns nonzero for an incomplete collection and only writes a triage report', async () => {
+  const original = {
+    read: fs.readFileSync,
+    write: fs.writeFileSync,
+    mkdir: fs.mkdirSync,
+    fetch: global.fetch,
+    argv: process.argv,
+    log: console.log,
+    error: console.error,
+  }
+  const writes = []
+  try {
+    fs.readFileSync = () => LEDGER
+    fs.mkdirSync = () => {}
+    fs.writeFileSync = (destination, content) => writes.push({ destination, content })
+    global.fetch = async () => ({ ok: false, status: 503 })
+    process.argv = ['node', 'fetch-disclosures.js', '--until', '2026-09-11']
+    console.log = () => {}
+    console.error = () => {}
+    assert.equal(await run(), 1)
+    assert.equal(writes.length, 1)
+    assert.match(writes[0].destination, /\.security-triage\/disclosures-.*\.json$/)
+    assert.equal(JSON.parse(writes[0].content).collection_complete, false)
+  } finally {
+    fs.readFileSync = original.read
+    fs.writeFileSync = original.write
+    fs.mkdirSync = original.mkdir
+    global.fetch = original.fetch
+    process.argv = original.argv
+    console.log = original.log
+    console.error = original.error
+  }
+})


### PR DESCRIPTION
The disclosure ledger is missing the August Accounting Oracle / VEBO post-mortem, and there is no repeatable way to compare forum disclosures against it. This adds a manual candidate collector and the reviewed ledger entry.

Stacked on #960. The base is `chore/update-audits-and-lips` so this PR shows only the disclosure additions. After #960 merges, retarget this PR to `main` and update its base as needed.

### Changes

- Add `npm run fetch-disclosures`, using #960's existing `lib/http`, `lib/markdown`, and `lib/tasks` helpers and exported `run()` convention.
- Discover keyword-matched forum topics, including weakness/weaknesses, within an inclusive UTC activity window, fetch their complete post streams in batches, and compare numeric topic ids against the local ledger.
- Write timestamped reports into the existing ignored `.security-triage/` directory, containing source links, ids, dates, hashes, candidates, already-listed topics, routing exclusions, and errors. Do not persist titles, bodies, or author identities.
- Return nonzero for incomplete pagination or failed topic collection. Document that keyword selection and product routing require human review and cannot establish exhaustive disclosure coverage.
- Add the August 6 Accounting Oracle / VEBO post-mortem as `Incident / Low`, and clarify that the main ledger focuses on Lido's staking business.
- Add mocked regression tests and manual usage documentation.

The existing audit/LIP/quorum fetchers, aggregate fetch command, shared helpers, redirects, dependencies, and CI workflows are unchanged. Live forum collection is a separate manual command; it does not publish ledger rows or assign severity.

### Evidence and validation

Source: https://research.lido.fi/t/11756/3 — August 6 is the post-mortem publication date. `Low` is the reviewed editorial classification.

- `npm test`: 82 tests passed (70 inherited and 12 new).
- `npm run build`: passed.
- `git diff --check`: passed.
- Live collection for March 23–September 11 against #960's original ledger: candidate `11756`, already-listed `11342`, nine product/operator exclusions, complete collection, zero errors.
- Live collection for March 23–September 12 against the updated ledger: zero new candidates, two already-listed disclosures, nine exclusions, complete collection, zero errors.

```sh
npm run fetch-disclosures
npm run fetch-disclosures -- --since 2026-03-23 --until 2026-09-11
```
